### PR TITLE
Feat: 테이블 생성 api 구현

### DIFF
--- a/queosk/src/main/java/com/bttf/queosk/controller/TableController.java
+++ b/queosk/src/main/java/com/bttf/queosk/controller/TableController.java
@@ -1,0 +1,25 @@
+package com.bttf.queosk.controller;
+
+import com.bttf.queosk.dto.tableDto.TableForm;
+import com.bttf.queosk.mapper.TableMapper;
+import com.bttf.queosk.service.TableService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/restaurant/{restaurantId}")
+@RequiredArgsConstructor
+public class TableController {
+    private final TableService tableService;
+
+    public ResponseEntity<?> tableCreate(@RequestHeader(HttpHeaders.AUTHORIZATION) String token,
+                                      @PathVariable(name = "restaurantId") Long restaurantId) {
+        tableService.createTable(restaurantId);
+        return ResponseEntity.status(201).build();
+    }
+}

--- a/queosk/src/main/java/com/bttf/queosk/dto/tableDto/TableDto.java
+++ b/queosk/src/main/java/com/bttf/queosk/dto/tableDto/TableDto.java
@@ -1,0 +1,6 @@
+package com.bttf.queosk.dto.tableDto;
+
+public class TableDto {
+    private Long userId;
+    private Long restaurantId;
+}

--- a/queosk/src/main/java/com/bttf/queosk/dto/tableDto/TableForm.java
+++ b/queosk/src/main/java/com/bttf/queosk/dto/tableDto/TableForm.java
@@ -1,0 +1,10 @@
+package com.bttf.queosk.dto.tableDto;
+
+import lombok.Builder;
+
+@Builder
+public class TableForm {
+    private Long userId;
+    private Long restaurantId;
+
+}

--- a/queosk/src/main/java/com/bttf/queosk/entity/MenuEntity.java
+++ b/queosk/src/main/java/com/bttf/queosk/entity/MenuEntity.java
@@ -1,7 +1,7 @@
 package com.bttf.queosk.entity;
 
 import com.bttf.queosk.config.BaseTimeEntity;
-import com.bttf.queosk.domain.enumerate.MenuStatus;
+import com.bttf.queosk.model.MenuStatus;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/queosk/src/main/java/com/bttf/queosk/entity/OrderEntity.java
+++ b/queosk/src/main/java/com/bttf/queosk/entity/OrderEntity.java
@@ -1,7 +1,7 @@
 package com.bttf.queosk.entity;
 
 import com.bttf.queosk.config.BaseTimeEntity;
-import com.bttf.queosk.domain.enumerate.OrderStatus;
+import com.bttf.queosk.model.OrderStatus;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/queosk/src/main/java/com/bttf/queosk/entity/RestaurantEntity.java
+++ b/queosk/src/main/java/com/bttf/queosk/entity/RestaurantEntity.java
@@ -1,8 +1,8 @@
 package com.bttf.queosk.entity;
 
 import com.bttf.queosk.config.BaseTimeEntity;
-import com.bttf.queosk.domain.enumerate.OperationStatus;
-import com.bttf.queosk.domain.enumerate.RestaurantCategory;
+import com.bttf.queosk.model.OperationStatus;
+import com.bttf.queosk.model.RestaurantCategory;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/queosk/src/main/java/com/bttf/queosk/entity/TableEntity.java
+++ b/queosk/src/main/java/com/bttf/queosk/entity/TableEntity.java
@@ -1,7 +1,7 @@
 package com.bttf.queosk.entity;
 
 import com.bttf.queosk.config.BaseTimeEntity;
-import com.bttf.queosk.domain.enumerate.TableStatus;
+import com.bttf.queosk.model.TableStatus;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -20,11 +20,16 @@ public class TableEntity extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private long id;
+    private Long id;
 
     private TableStatus status;
 
-    @ManyToOne
-    @JoinColumn(name = "restaurant_id")
-    private RestaurantEntity restaurant;
+    private long restaurantId;
+
+    public static TableEntity of(long restaurantId) {
+        return TableEntity.builder()
+                .status(TableStatus.OPEN)
+                .restaurantId(restaurantId)
+                .build();
+    }
 }

--- a/queosk/src/main/java/com/bttf/queosk/entity/UserEntity.java
+++ b/queosk/src/main/java/com/bttf/queosk/entity/UserEntity.java
@@ -1,8 +1,8 @@
 package com.bttf.queosk.entity;
 
 import com.bttf.queosk.config.BaseTimeEntity;
-import com.bttf.queosk.domain.enumerate.LoginType;
-import com.bttf.queosk.domain.enumerate.UserStatus;
+import com.bttf.queosk.model.LoginType;
+import com.bttf.queosk.model.UserStatus;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/queosk/src/main/java/com/bttf/queosk/mapper/TableMapper.java
+++ b/queosk/src/main/java/com/bttf/queosk/mapper/TableMapper.java
@@ -1,0 +1,14 @@
+package com.bttf.queosk.mapper;
+
+import com.bttf.queosk.dto.tableDto.TableDto;
+import com.bttf.queosk.dto.tableDto.TableForm;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface TableMapper {
+    TableMapper INSTANCE = Mappers.getMapper(TableMapper.class);
+
+    TableDto toTableDto(TableForm tableForm);
+
+}

--- a/queosk/src/main/java/com/bttf/queosk/model/LoginType.java
+++ b/queosk/src/main/java/com/bttf/queosk/model/LoginType.java
@@ -1,4 +1,4 @@
-package com.bttf.queosk.domain.enumerate;
+package com.bttf.queosk.model;
 
 public enum LoginType {
     NORMAL, KAKAO

--- a/queosk/src/main/java/com/bttf/queosk/model/MenuStatus.java
+++ b/queosk/src/main/java/com/bttf/queosk/model/MenuStatus.java
@@ -1,4 +1,4 @@
-package com.bttf.queosk.domain.enumerate;
+package com.bttf.queosk.model;
 
 public enum MenuStatus {
     SOLD_OUT, ON_SALE

--- a/queosk/src/main/java/com/bttf/queosk/model/OperationStatus.java
+++ b/queosk/src/main/java/com/bttf/queosk/model/OperationStatus.java
@@ -1,4 +1,4 @@
-package com.bttf.queosk.domain.enumerate;
+package com.bttf.queosk.model;
 
 public enum OperationStatus {
     OPEN,

--- a/queosk/src/main/java/com/bttf/queosk/model/OrderStatus.java
+++ b/queosk/src/main/java/com/bttf/queosk/model/OrderStatus.java
@@ -1,4 +1,4 @@
-package com.bttf.queosk.domain.enumerate;
+package com.bttf.queosk.model;
 
 public enum OrderStatus {
     IN_PROGRESS, DONE, CANCELED

--- a/queosk/src/main/java/com/bttf/queosk/model/RestaurantCategory.java
+++ b/queosk/src/main/java/com/bttf/queosk/model/RestaurantCategory.java
@@ -1,4 +1,4 @@
-package com.bttf.queosk.domain.enumerate;
+package com.bttf.queosk.model;
 
 public enum RestaurantCategory {
     DONKASU_SUSHI_JAPANESE,

--- a/queosk/src/main/java/com/bttf/queosk/model/TableStatus.java
+++ b/queosk/src/main/java/com/bttf/queosk/model/TableStatus.java
@@ -1,4 +1,4 @@
-package com.bttf.queosk.domain.enumerate;
+package com.bttf.queosk.model;
 
 public enum TableStatus {
     USING, OPEN

--- a/queosk/src/main/java/com/bttf/queosk/model/UserStatus.java
+++ b/queosk/src/main/java/com/bttf/queosk/model/UserStatus.java
@@ -1,4 +1,4 @@
-package com.bttf.queosk.domain.enumerate;
+package com.bttf.queosk.model;
 
 public enum UserStatus {
     VERIFIED,

--- a/queosk/src/main/java/com/bttf/queosk/service/TableService.java
+++ b/queosk/src/main/java/com/bttf/queosk/service/TableService.java
@@ -1,0 +1,29 @@
+package com.bttf.queosk.service;
+
+
+import com.bttf.queosk.entity.TableEntity;
+import com.bttf.queosk.repository.RestaurantRepository;
+import com.bttf.queosk.repository.TableRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class TableService {
+
+    private final TableRepository tableRepository;
+
+    private final RestaurantRepository restaurantRepository;
+
+    public void createTable(Long restaurantId) {
+
+        restaurantRepository.findById(restaurantId).orElseThrow(
+                () -> new RuntimeException()
+        );
+
+        tableRepository.save(TableEntity.of(restaurantId));
+    }
+}

--- a/queosk/src/test/java/com/bttf/queosk/repository/CommentRepositoryTest.java
+++ b/queosk/src/test/java/com/bttf/queosk/repository/CommentRepositoryTest.java
@@ -1,7 +1,7 @@
 package com.bttf.queosk.repository;
 
 import com.bttf.queosk.config.JpaAuditingConfiguration;
-import com.bttf.queosk.domain.enumerate.UserStatus;
+import com.bttf.queosk.model.UserStatus;
 import com.bttf.queosk.entity.CommentEntity;
 import com.bttf.queosk.entity.RestaurantEntity;
 import com.bttf.queosk.entity.ReviewEntity;

--- a/queosk/src/test/java/com/bttf/queosk/repository/OrderRepositoryTest.java
+++ b/queosk/src/test/java/com/bttf/queosk/repository/OrderRepositoryTest.java
@@ -10,7 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 
-import static com.bttf.queosk.domain.enumerate.TableStatus.OPEN;
+import static com.bttf.queosk.model.TableStatus.OPEN;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Import(JpaAuditingConfiguration.class)

--- a/queosk/src/test/java/com/bttf/queosk/repository/QueueRepositoryTest.java
+++ b/queosk/src/test/java/com/bttf/queosk/repository/QueueRepositoryTest.java
@@ -1,17 +1,12 @@
 package com.bttf.queosk.repository;
 
-import com.bttf.queosk.config.JpaAuditingConfiguration;
-import com.bttf.queosk.domain.enumerate.UserStatus;
+import com.bttf.queosk.model.UserStatus;
 import com.bttf.queosk.entity.QueueEntity;
 import com.bttf.queosk.entity.RestaurantEntity;
 import com.bttf.queosk.entity.UserEntity;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.redis.DataRedisTest;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Import;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 @DataRedisTest
 class QueueRepositoryTest {

--- a/queosk/src/test/java/com/bttf/queosk/repository/ReviewRepositoryTest.java
+++ b/queosk/src/test/java/com/bttf/queosk/repository/ReviewRepositoryTest.java
@@ -1,11 +1,10 @@
 package com.bttf.queosk.repository;
 
 import com.bttf.queosk.config.JpaAuditingConfiguration;
-import com.bttf.queosk.domain.enumerate.UserStatus;
+import com.bttf.queosk.model.UserStatus;
 import com.bttf.queosk.entity.RestaurantEntity;
 import com.bttf.queosk.entity.ReviewEntity;
 import com.bttf.queosk.entity.UserEntity;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;

--- a/queosk/src/test/java/com/bttf/queosk/repository/SettlementRepositoryTest.java
+++ b/queosk/src/test/java/com/bttf/queosk/repository/SettlementRepositoryTest.java
@@ -9,7 +9,7 @@ import org.springframework.context.annotation.Import;
 
 import java.time.LocalDateTime;
 
-import static com.bttf.queosk.domain.enumerate.TableStatus.OPEN;
+import static com.bttf.queosk.model.TableStatus.OPEN;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Import(JpaAuditingConfiguration.class)

--- a/queosk/src/test/java/com/bttf/queosk/repository/TableRepositoryTest.java
+++ b/queosk/src/test/java/com/bttf/queosk/repository/TableRepositoryTest.java
@@ -8,7 +8,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 
-import static com.bttf.queosk.domain.enumerate.TableStatus.OPEN;
+import static com.bttf.queosk.model.TableStatus.OPEN;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Import(JpaAuditingConfiguration.class)

--- a/queosk/src/test/java/com/bttf/queosk/repository/UserRepositoryTest.java
+++ b/queosk/src/test/java/com/bttf/queosk/repository/UserRepositoryTest.java
@@ -1,7 +1,7 @@
 package com.bttf.queosk.repository;
 
 import com.bttf.queosk.config.JpaAuditingConfiguration;
-import com.bttf.queosk.domain.enumerate.UserStatus;
+import com.bttf.queosk.model.UserStatus;
 import com.bttf.queosk.entity.UserEntity;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
### 작업 내용
테이블 생성 api 구현
### 변경 사항(추가시엔 추가사항)
- TableController 생성
   - tabelCreate 메서드 생성
- TableService 생성
  - createTable 메서드 생성
-   TableEntity 수정
    - 기존의 @ManyToOne 으로 Restaurant 를 받던 부분을 restaurantId만 받을 수 있게 수정
    - of 메서드 생성

### 특이 사항
없음

### 관련 이슈(옵셔널)
없음