### PR TITLE
Feat: Exception 설정

### DIFF
--- a/queosk/src/main/java/com/bttf/queosk/exception/CustomException.java
+++ b/queosk/src/main/java/com/bttf/queosk/exception/CustomException.java
@@ -1,0 +1,13 @@
+package com.bttf.queosk.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public CustomException(ErrorCode e) {
+        super(e.getMessage());
+        this.errorCode = e;
+    }
+}

--- a/queosk/src/main/java/com/bttf/queosk/exception/ErrorCode.java
+++ b/queosk/src/main/java/com/bttf/queosk/exception/ErrorCode.java
@@ -1,0 +1,18 @@
+package com.bttf.queosk.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+@Getter
+public enum ErrorCode {
+
+    // ex) NOT_FOUND_USER(HttpStatus.BAD_REQUEST, "회원 정보를 찾을 수 없습니다.")
+    ;
+
+
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/queosk/src/main/java/com/bttf/queosk/exception/ErrorResponse.java
+++ b/queosk/src/main/java/com/bttf/queosk/exception/ErrorResponse.java
@@ -1,0 +1,11 @@
+package com.bttf.queosk.exception;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class ErrorResponse {
+    private ErrorCode errorCode;
+    private String message;
+}

--- a/queosk/src/main/java/com/bttf/queosk/exception/GlobalExceptionHandler.java
+++ b/queosk/src/main/java/com/bttf/queosk/exception/GlobalExceptionHandler.java
@@ -1,0 +1,37 @@
+package com.bttf.queosk.exception;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<List<String>> handleValidException(
+            MethodArgumentNotValidException exception) {
+
+        List<String> errors = new ArrayList<>();
+        exception.getBindingResult().getAllErrors()
+                .forEach(error -> errors.add(error.getDefaultMessage()));
+
+        return ResponseEntity.status(400).body(errors);
+    }
+
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ErrorResponse> handleCustomException(CustomException exception) {
+        ErrorResponse errorResponse = ErrorResponse.builder()
+                .errorCode(exception.getErrorCode())
+                .message(exception.getMessage())
+                .build();
+
+        return ResponseEntity
+                .status(errorResponse.getErrorCode().getStatus())
+                .body(errorResponse);
+    }
+
+}


### PR DESCRIPTION
### 작업 내용
exception 에 대한 설정을 하였습니다

### 변경 사항(추가시엔 추가사항)
CustomException 설정
커스텀익셉션은 Enum 클래스인 ErrorCode.java 에 예시와 같은 형식으로 추가 해주시면 됩니다.
전역 예외처리 설정
 
 
 
- ValidException 응답 형식
```
(header)
HTTP/1.1 400 (400으로 동일)
   .
   .
(body)
[
    "아이디는 비워둘 수 없습니다.",
    "가게명은 비워둘 수 없습니다."
]
```

- CustomException 응답 형식

```
(header)
HTTP/1.1 400 (HttpStatus 에 따라 다른 상태코드)
   .
   .
(body)
{
    "errorCode": "NOT_FOUND_USER",
    "message": "회원 정보를 찾을 수 없습니다."
}
```

### 특이 사항
ValidException 에러 처리 응답은 json 이 아닌 List<String> 형태로 설정하였습니다.