### PR TITLE
Feature/user signin

### DIFF
--- a/queosk/build.gradle
+++ b/queosk/build.gradle
@@ -69,8 +69,10 @@ dependencies {
 	// https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-webflux
 	implementation group: 'org.springframework.boot', name: 'spring-boot-starter-webflux', version: '2.7.14'
 
-
-
+	// jwt 관련 의존성
+	implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.2'
+	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'
+	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.2'
 }
 
 tasks.named('test') {

--- a/queosk/src/main/java/com/bttf/queosk/ImageService/ImageService.java
+++ b/queosk/src/main/java/com/bttf/queosk/ImageService/ImageService.java
@@ -1,0 +1,10 @@
+package com.bttf.queosk.ImageService;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public class ImageService {
+    public String uploadImageAndGetUrl(MultipartFile imageFile) {
+        //TODO
+        return null;
+    }
+}

--- a/queosk/src/main/java/com/bttf/queosk/config/JwtFilter.java
+++ b/queosk/src/main/java/com/bttf/queosk/config/JwtFilter.java
@@ -1,6 +1,6 @@
 package com.bttf.queosk.config;
 
-import com.bttf.queosk.service.RefreshTokenService;
+import com.bttf.queosk.service.RefreshTokenService.RefreshTokenService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.core.Authentication;
@@ -45,9 +45,10 @@ public class JwtFilter extends OncePerRequestFilter {
                 String newAccessToken = refreshTokenService.issueNewAccessToken(email);
                 response.setHeader(HttpHeaders.AUTHORIZATION, newAccessToken);
                 response.setStatus(HttpServletResponse.SC_OK); // 200 Ok
-            }else{
+                response.getWriter().write("토큰이 갱신되었습니다.");
+            } else {
                 response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // 401 Unauthorized
-                response.getWriter().write("리프레시 토큰이 만료되었습니다. 다시 로그인 하세요.");
+                response.getWriter().write("토큰이 만료되었습니다. 다시 로그인 하세요.");
                 response.getWriter().flush();
             }
         }

--- a/queosk/src/main/java/com/bttf/queosk/config/JwtFilter.java
+++ b/queosk/src/main/java/com/bttf/queosk/config/JwtFilter.java
@@ -1,0 +1,66 @@
+package com.bttf.queosk.config;
+
+import com.bttf.queosk.service.RefreshTokenService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@RequiredArgsConstructor
+@Component
+public class JwtFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RefreshTokenService refreshTokenService;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain chain) throws ServletException, IOException {
+
+        String token = getTokenFromRequest(request);
+
+        if (token != null && jwtTokenProvider.validateToken(token)) {
+
+            Authentication authentication = jwtTokenProvider.getAuthentication(token);
+
+            SecurityContextHolder
+                    .getContext()
+                    .setAuthentication(authentication);
+        } else {
+            //만약 AccessToken이 유효하지 않을 경우 사용자의 이메일로 RefreshToken 조회
+            String email = jwtTokenProvider.getEmailFromToken(token);
+            String refreshToken = refreshTokenService.getRefreshToken(email);
+
+            //리프레시 토큰이 유효할 경우 , 헤더에 리프레시 토큰 담기
+            if (jwtTokenProvider.validateToken(refreshToken)) {
+                String newAccessToken = refreshTokenService.issueNewAccessToken(email);
+                response.setHeader(HttpHeaders.AUTHORIZATION, newAccessToken);
+                response.setStatus(HttpServletResponse.SC_OK); // 200 Ok
+            }else{
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // 401 Unauthorized
+                response.getWriter().write("리프레시 토큰이 만료되었습니다. 다시 로그인 하세요.");
+                response.getWriter().flush();
+            }
+        }
+        chain.doFilter(request, response);
+    }
+
+    private String getTokenFromRequest(HttpServletRequest request) {
+
+        String bearerToken = request.getHeader(HttpHeaders.AUTHORIZATION);
+
+        if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+}

--- a/queosk/src/main/java/com/bttf/queosk/config/JwtTokenProvider.java
+++ b/queosk/src/main/java/com/bttf/queosk/config/JwtTokenProvider.java
@@ -1,0 +1,103 @@
+package com.bttf.queosk.config;
+
+import com.bttf.queosk.dto.tokenDto.TokenDto;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.oauth2.jwt.JwtException;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+import java.security.Key;
+import java.util.Date;
+
+@RequiredArgsConstructor
+@Component
+public class JwtTokenProvider {
+
+    private final UserDetailsService userDetailsService;
+
+    @Value("${jwt.secretKey}")
+    private String secretKey;
+
+    @Value("${jwt.tokenIssuer}")
+    private String issuer;
+    private Key key;
+
+    @PostConstruct
+    public void init() {
+        key = Keys.secretKeyFor(SignatureAlgorithm.HS256);
+    }
+
+    public String generateAccessToken(TokenDto tokenDto) {
+        return Jwts.builder()
+                .setSubject(tokenDto.getId().toString())
+                .claim("email", tokenDto.getEmail())
+                .setIssuer(issuer)
+                .setIssuedAt(new Date(System.currentTimeMillis()))
+                .setExpiration(new Date(System.currentTimeMillis() + (60 * 60 * 1000)))
+                .signWith(key)
+                .compact();
+    }
+
+    public String generateRefreshToken() {
+        return Jwts.builder()
+                .setIssuer(issuer)
+                .setIssuedAt(new Date(System.currentTimeMillis()))
+                .setExpiration(new Date(System.currentTimeMillis() + (60 * 60 * 1000)))
+                .signWith(key)
+                .compact();
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(token);
+            return true;
+        } catch (JwtException ex) {
+            return false;
+        }
+    }
+
+    public Long getIdFromToken(String token) {
+        return Long.parseLong(Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .getSubject());
+    }
+
+    public String getEmailFromToken(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .get("email", String.class);
+    }
+
+    public Authentication getAuthentication(String token) {
+
+        String email = Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .get("email", String.class);
+
+        UserDetails userDetails = userDetailsService.loadUserByUsername(email);
+
+        return new UsernamePasswordAuthenticationToken(
+                userDetails, "", userDetails.getAuthorities()
+        );
+    }
+}

--- a/queosk/src/main/java/com/bttf/queosk/config/SecurityConfig.java
+++ b/queosk/src/main/java/com/bttf/queosk/config/SecurityConfig.java
@@ -5,6 +5,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
@@ -12,15 +14,14 @@ import org.springframework.security.web.SecurityFilterChain;
 @RequiredArgsConstructor
 @EnableWebSecurity
 public class SecurityConfig {
-
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        http.csrf(c -> c.disable()).cors(c -> c.disable())
-                .headers(c -> c.frameOptions(f -> f.disable()).disable())
-                .authorizeHttpRequests(auth -> auth.antMatchers("/error").permitAll())
-                .authorizeHttpRequests(auth -> auth.antMatchers("/favicion").permitAll())
-                .authorizeHttpRequests(auth -> auth.antMatchers("/h2-console/**").permitAll())
-                .authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
+        http.csrf(AbstractHttpConfigurer::disable)
+                .cors(AbstractHttpConfigurer::disable)
+                .headers(c -> c.frameOptions(HeadersConfigurer.FrameOptionsConfig::disable).disable())
+                //개발 초기 일단 모두 permitAll
+                .authorizeHttpRequests(auth -> auth.antMatchers("/**").permitAll());
+
         return http.build();
     }
 

--- a/queosk/src/main/java/com/bttf/queosk/controller/UserController.java
+++ b/queosk/src/main/java/com/bttf/queosk/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.bttf.queosk.controller;
 
+import com.bttf.queosk.dto.userDto.UserSignInForm;
 import com.bttf.queosk.dto.userDto.UserSignUpForm;
 import com.bttf.queosk.service.userService.UserService;
 import io.swagger.annotations.Api;
@@ -28,5 +29,14 @@ public class UserController {
         userService.createUser(userSignUpForm);
 
         return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @PostMapping("/signin")
+    @ApiOperation(value = "사용자 로그인", notes = "입력된 정보로 로그인을 진행합니다.")
+    public ResponseEntity<?> signIn(@Valid @RequestBody UserSignInForm userSignInForm) {
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(userService.signInUser(userSignInForm));
     }
 }

--- a/queosk/src/main/java/com/bttf/queosk/controller/UserController.java
+++ b/queosk/src/main/java/com/bttf/queosk/controller/UserController.java
@@ -1,0 +1,32 @@
+package com.bttf.queosk.controller;
+
+import com.bttf.queosk.dto.userDto.UserSignUpForm;
+import com.bttf.queosk.service.userService.UserService;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+@RequiredArgsConstructor
+@Api(tags = "User API", description = "사용자와 관련된 API")
+@RequestMapping("/api/users")
+@RestController
+public class UserController {
+    private final UserService userService;
+
+    @PostMapping("/signup")
+    @ApiOperation(value = "사용자 회원가입", notes = "입력된 정보로 회원가입을 진행합니다.")
+    public ResponseEntity<?> createUser(@Valid @RequestBody UserSignUpForm userSignUpForm) {
+
+        userService.createUser(userSignUpForm);
+
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+}

--- a/queosk/src/main/java/com/bttf/queosk/dto/tokenDto/TokenDto.java
+++ b/queosk/src/main/java/com/bttf/queosk/dto/tokenDto/TokenDto.java
@@ -1,0 +1,15 @@
+package com.bttf.queosk.dto.tokenDto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class TokenDto {
+    private String email;
+    private Long id;
+}

--- a/queosk/src/main/java/com/bttf/queosk/dto/userDto/UserSignInDto.java
+++ b/queosk/src/main/java/com/bttf/queosk/dto/userDto/UserSignInDto.java
@@ -1,0 +1,18 @@
+package com.bttf.queosk.dto.userDto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class UserSignInDto {
+    private String accessToken;
+    private String refreshToken;
+    private String email;
+    private String nickname;
+    private String imageUrl;
+}

--- a/queosk/src/main/java/com/bttf/queosk/dto/userDto/UserSignInForm.java
+++ b/queosk/src/main/java/com/bttf/queosk/dto/userDto/UserSignInForm.java
@@ -1,0 +1,25 @@
+package com.bttf.queosk.dto.userDto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class UserSignInForm {
+
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
+    @NotBlank(message = "이메일은 비워둘 수 없습니다.")
+    private String email;
+
+    @Size(min = 2, max = 10, message = "닉네임은 2~10자 사이로 입력해주세요.")
+    @NotBlank(message = "비밀번호는 비워둘 수 없습니다.")
+    private String password;
+}

--- a/queosk/src/main/java/com/bttf/queosk/dto/userDto/UserSignUpForm.java
+++ b/queosk/src/main/java/com/bttf/queosk/dto/userDto/UserSignUpForm.java
@@ -1,0 +1,33 @@
+package com.bttf.queosk.dto.userDto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class UserSignUpForm {
+
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
+    @NotBlank(message = "이메일은 비워둘 수 없습니다.")
+    private String email;
+
+    @Size(min = 4, max = 12, message = "비밀번호는 4~20자 이내로 입력해주세요.")
+    @NotBlank(message = "닉네임은 비워둘 수 없습니다.")
+    private String nickName;
+
+    @Size(min = 2, max = 10, message = "닉네임은 2~10자 사이로 입력해주세요.")
+    @NotBlank(message = "비밀번호는 비워둘 수 없습니다.")
+    private String password;
+
+    @Size(min = 10, max = 14, message = "휴대전화번호는 10~14자 이내로 입력해주세요.")
+    @NotBlank(message = "휴대전화번호는 비워둘 수 없습니다.")
+    private String phone;
+}

--- a/queosk/src/main/java/com/bttf/queosk/entity/RefreshToken.java
+++ b/queosk/src/main/java/com/bttf/queosk/entity/RefreshToken.java
@@ -1,0 +1,19 @@
+package com.bttf.queosk.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@RedisHash(value = "refresh_token")
+public class RefreshToken {
+    @Id
+    private String user_email;
+    private String refresh_token;
+}

--- a/queosk/src/main/java/com/bttf/queosk/entity/User.java
+++ b/queosk/src/main/java/com/bttf/queosk/entity/User.java
@@ -1,8 +1,7 @@
 package com.bttf.queosk.entity;
 
 import com.bttf.queosk.config.BaseTimeEntity;
-import com.bttf.queosk.dto.LoginType;
-import com.bttf.queosk.dto.UserStatus;
+import com.bttf.queosk.model.UserStatus;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -23,7 +22,7 @@ public class User extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private String userId;
+    private String nickName;
 
     private String email;
 
@@ -32,12 +31,9 @@ public class User extends BaseTimeEntity {
     private String phone;
 
     @Enumerated(EnumType.STRING)
-    private LoginType loginType;
-
-    @Enumerated(EnumType.STRING)
     private UserStatus status;
 
     private String imageUrl;
 
-    private String refreshToken;
+    private String loginApi;
 }

--- a/queosk/src/main/java/com/bttf/queosk/exception/ErrorCode.java
+++ b/queosk/src/main/java/com/bttf/queosk/exception/ErrorCode.java
@@ -9,8 +9,12 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
 
     // ex) NOT_FOUND_USER(HttpStatus.BAD_REQUEST, "회원 정보를 찾을 수 없습니다.")
-    ;
 
+    //UserService 관련 Exception
+    INVALID_USER_ID(HttpStatus.NOT_FOUND, "존재하지 않는 아이디입니다."),
+    EXISTING_USER(HttpStatus.BAD_REQUEST, "이미 가입된 회원입니다."),
+    PASSWORD_NOT_MATCH(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다.")
+    ;
 
 
     private final HttpStatus status;

--- a/queosk/src/main/java/com/bttf/queosk/mapper/UserSignInMapper.java
+++ b/queosk/src/main/java/com/bttf/queosk/mapper/UserSignInMapper.java
@@ -1,0 +1,17 @@
+package com.bttf.queosk.mapper;
+
+import com.bttf.queosk.dto.userDto.UserSignInDto;
+import com.bttf.queosk.entity.User;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface UserSignInMapper {
+    UserSignInMapper INSTANCE = Mappers.getMapper(UserSignInMapper.class);
+
+    @Mapping(source = "user.email", target = "email")
+    @Mapping(source = "user.nickName", target = "nickname")
+    @Mapping(source = "user.imageUrl", target = "imageUrl")
+    UserSignInDto userToUserSignInDto(User user, String refreshToken, String accessToken);
+}

--- a/queosk/src/main/java/com/bttf/queosk/model/UserStatus.java
+++ b/queosk/src/main/java/com/bttf/queosk/model/UserStatus.java
@@ -1,4 +1,4 @@
-package com.bttf.queosk.dto;
+package com.bttf.queosk.model;
 
 public enum UserStatus {
     VERIFIED,

--- a/queosk/src/main/java/com/bttf/queosk/repository/RefreshTokenRepository.java
+++ b/queosk/src/main/java/com/bttf/queosk/repository/RefreshTokenRepository.java
@@ -1,0 +1,8 @@
+package com.bttf.queosk.repository;
+
+import com.bttf.queosk.entity.RefreshToken;
+import org.springframework.data.repository.CrudRepository;
+
+public interface RefreshTokenRepository extends CrudRepository<RefreshToken, String> {
+    String findByUserEmail(String email);
+}

--- a/queosk/src/main/java/com/bttf/queosk/repository/UserRepository.java
+++ b/queosk/src/main/java/com/bttf/queosk/repository/UserRepository.java
@@ -4,6 +4,9 @@ import com.bttf.queosk.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
 }

--- a/queosk/src/main/java/com/bttf/queosk/service/RefreshTokenService/RefreshTokenService.java
+++ b/queosk/src/main/java/com/bttf/queosk/service/RefreshTokenService/RefreshTokenService.java
@@ -1,0 +1,38 @@
+package com.bttf.queosk.service.RefreshTokenService;
+
+import com.bttf.queosk.config.JwtTokenProvider;
+import com.bttf.queosk.dto.tokenDto.TokenDto;
+import com.bttf.queosk.entity.User;
+import com.bttf.queosk.exception.CustomException;
+import com.bttf.queosk.repository.RefreshTokenRepository;
+import com.bttf.queosk.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import static com.bttf.queosk.exception.ErrorCode.INVALID_USER_ID;
+
+@RequiredArgsConstructor
+@Service
+public class RefreshTokenService {
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final UserRepository userRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    // 고객 이메일로 리프레시 토큰 리턴
+    public String getRefreshToken(String email) {
+        return refreshTokenRepository.findByUserEmail(email);
+    }
+
+    // 신규 AccessToken 발급
+    public String issueNewAccessToken(String email) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new CustomException(INVALID_USER_ID));
+
+        return jwtTokenProvider.generateAccessToken(
+                TokenDto.builder()
+                        .id(user.getId())
+                        .email(user.getEmail())
+                        .build()
+        );
+    }
+}

--- a/queosk/src/main/java/com/bttf/queosk/service/userService/UserService.java
+++ b/queosk/src/main/java/com/bttf/queosk/service/userService/UserService.java
@@ -1,0 +1,8 @@
+package com.bttf.queosk.service.userService;
+
+import com.bttf.queosk.dto.userDto.UserSignUpForm;
+
+public interface UserService {
+    void createUser(UserSignUpForm userSignUpForm);
+
+}

--- a/queosk/src/main/java/com/bttf/queosk/service/userService/UserService.java
+++ b/queosk/src/main/java/com/bttf/queosk/service/userService/UserService.java
@@ -1,8 +1,11 @@
 package com.bttf.queosk.service.userService;
 
+import com.bttf.queosk.dto.userDto.UserSignInDto;
+import com.bttf.queosk.dto.userDto.UserSignInForm;
 import com.bttf.queosk.dto.userDto.UserSignUpForm;
 
 public interface UserService {
     void createUser(UserSignUpForm userSignUpForm);
 
+    UserSignInDto signInUser(UserSignInForm userSignInForm);
 }

--- a/queosk/src/main/java/com/bttf/queosk/service/userService/UserServiceImpl.java
+++ b/queosk/src/main/java/com/bttf/queosk/service/userService/UserServiceImpl.java
@@ -1,0 +1,50 @@
+package com.bttf.queosk.service.userService;
+
+import com.bttf.queosk.config.JwtTokenProvider;
+import com.bttf.queosk.dto.userDto.UserSignUpForm;
+import com.bttf.queosk.entity.User;
+import com.bttf.queosk.exception.CustomException;
+import com.bttf.queosk.repository.RefreshTokenRepository;
+import com.bttf.queosk.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import static com.bttf.queosk.exception.ErrorCode.EXISTING_USER;
+import static com.bttf.queosk.model.UserStatus.NOT_VERIFIED;
+
+@RequiredArgsConstructor
+@Service
+public class UserServiceImpl implements UserService {
+    private final UserRepository userRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final BCryptPasswordEncoder passwordEncoder;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    public void createUser(UserSignUpForm userSignUpForm) {
+
+        //기존회원 여부 확인
+        userRepository.findByEmail(userSignUpForm.getEmail()).ifPresent(
+                user -> {
+                    throw new CustomException(EXISTING_USER);
+                });
+
+        //비밀번호 암호화
+        String encryptedPassword = passwordEncoder.encode(userSignUpForm.getPassword());
+
+        //회원 휴대폰 번호 혹시라도 문자나 공백이 들어왔다면 처리
+        String trimmedPhoneNumber =
+                userSignUpForm.getPhone().replaceAll("\\D", "");
+
+        userRepository.save(
+                User.builder()
+                        .email(userSignUpForm.getEmail())
+                        .nickName(userSignUpForm.getNickName())
+                        .password(encryptedPassword)
+                        .phone(trimmedPhoneNumber)
+                        .status(NOT_VERIFIED)
+                        .build()
+        );
+    }
+}

--- a/queosk/src/main/java/com/bttf/queosk/service/userService/UserServiceImpl.java
+++ b/queosk/src/main/java/com/bttf/queosk/service/userService/UserServiceImpl.java
@@ -1,16 +1,21 @@
 package com.bttf.queosk.service.userService;
 
 import com.bttf.queosk.config.JwtTokenProvider;
+import com.bttf.queosk.dto.tokenDto.TokenDto;
+import com.bttf.queosk.dto.userDto.UserSignInDto;
+import com.bttf.queosk.dto.userDto.UserSignInForm;
 import com.bttf.queosk.dto.userDto.UserSignUpForm;
+import com.bttf.queosk.entity.RefreshToken;
 import com.bttf.queosk.entity.User;
 import com.bttf.queosk.exception.CustomException;
+import com.bttf.queosk.mapper.UserSignInMapper;
 import com.bttf.queosk.repository.RefreshTokenRepository;
 import com.bttf.queosk.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 
-import static com.bttf.queosk.exception.ErrorCode.EXISTING_USER;
+import static com.bttf.queosk.exception.ErrorCode.*;
 import static com.bttf.queosk.model.UserStatus.NOT_VERIFIED;
 
 @RequiredArgsConstructor
@@ -46,5 +51,39 @@ public class UserServiceImpl implements UserService {
                         .status(NOT_VERIFIED)
                         .build()
         );
+    }
+
+    @Override
+    public UserSignInDto signInUser(UserSignInForm userSignInForm) {
+
+        //입력된 email 로 사용자 조회
+        User user = userRepository.findByEmail(userSignInForm.getEmail())
+                .orElseThrow(() -> new CustomException(INVALID_USER_ID));
+
+        //조회된 사용자의 비밀번호와 입력된 비밀번호 비교
+        if (!passwordEncoder.matches(userSignInForm.getPassword(), user.getPassword())) {
+            throw new CustomException(PASSWORD_NOT_MATCH);
+        }
+
+        //엑세스 토큰 발행
+        String accessToken = jwtTokenProvider.generateAccessToken(
+                TokenDto.builder()
+                        .email(user.getEmail())
+                        .id(user.getId())
+                        .build()
+        );
+
+        //리프레시 토큰 발행
+        String refreshToken = jwtTokenProvider.generateRefreshToken();
+
+        //리프테시 토큰 저장(기존에 있었다면 덮어쓰기 - 성능상 조회 후 수정보다 덮어쓰기가 더 빠르고 가벼움)
+        refreshTokenRepository.save(
+                RefreshToken.builder()
+                        .user_email(user.getEmail())
+                        .refresh_token(refreshToken)
+                        .build()
+        );
+
+        return UserSignInMapper.INSTANCE.userToUserSignInDto(user, refreshToken, accessToken);
     }
 }

--- a/queosk/src/test/java/com/bttf/queosk/repository/CommentRepositoryTest.java
+++ b/queosk/src/test/java/com/bttf/queosk/repository/CommentRepositoryTest.java
@@ -1,7 +1,7 @@
 package com.bttf.queosk.repository;
 
 import com.bttf.queosk.config.JpaAuditingConfiguration;
-import com.bttf.queosk.dto.UserStatus;
+import com.bttf.queosk.model.UserStatus;
 import com.bttf.queosk.entity.Comment;
 import com.bttf.queosk.entity.Restaurant;
 import com.bttf.queosk.entity.Review;
@@ -35,7 +35,6 @@ class CommentRepositoryTest {
 
         User user = User.builder()
                 .id(1L)
-                .userId("test")
                 .email("a@x.com")
                 .password("test")
                 .phone("0100000000")

--- a/queosk/src/test/java/com/bttf/queosk/repository/QueueRepositoryTest.java
+++ b/queosk/src/test/java/com/bttf/queosk/repository/QueueRepositoryTest.java
@@ -1,6 +1,6 @@
 package com.bttf.queosk.repository;
 
-import com.bttf.queosk.dto.UserStatus;
+import com.bttf.queosk.model.UserStatus;
 import com.bttf.queosk.entity.Queue;
 import com.bttf.queosk.entity.Restaurant;
 import com.bttf.queosk.entity.User;
@@ -26,7 +26,6 @@ class QueueRepositoryTest {
 
         User user = User.builder()
                 .id(1L)
-                .userId("test")
                 .email("a@x.com")
                 .password("test")
                 .phone("0100000000")

--- a/queosk/src/test/java/com/bttf/queosk/repository/ReviewRepositoryTest.java
+++ b/queosk/src/test/java/com/bttf/queosk/repository/ReviewRepositoryTest.java
@@ -1,7 +1,7 @@
 package com.bttf.queosk.repository;
 
 import com.bttf.queosk.config.JpaAuditingConfiguration;
-import com.bttf.queosk.dto.UserStatus;
+import com.bttf.queosk.model.UserStatus;
 import com.bttf.queosk.entity.Restaurant;
 import com.bttf.queosk.entity.Review;
 import com.bttf.queosk.entity.User;
@@ -30,7 +30,6 @@ class ReviewRepositoryTest {
         // given
         User user = User.builder()
                 .id(1L)
-                .userId("test")
                 .email("a@x.com")
                 .password("test")
                 .phone("0100000000")

--- a/queosk/src/test/java/com/bttf/queosk/repository/UserRepositoryTest.java
+++ b/queosk/src/test/java/com/bttf/queosk/repository/UserRepositoryTest.java
@@ -1,7 +1,7 @@
 package com.bttf.queosk.repository;
 
 import com.bttf.queosk.config.JpaAuditingConfiguration;
-import com.bttf.queosk.dto.UserStatus;
+import com.bttf.queosk.model.UserStatus;
 import com.bttf.queosk.entity.User;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -24,7 +24,6 @@ class UserRepositoryTest {
         // given
         User user = User.builder()
                 .id(1L)
-                .userId("test")
                 .email("a@x.com")
                 .password("test")
                 .phone("0100000000")

--- a/queosk/src/test/java/com/bttf/queosk/service/userService/UserServiceTest.java
+++ b/queosk/src/test/java/com/bttf/queosk/service/userService/UserServiceTest.java
@@ -1,0 +1,80 @@
+package com.bttf.queosk.service.userService;
+
+import com.bttf.queosk.config.JwtTokenProvider;
+import com.bttf.queosk.dto.userDto.UserSignUpForm;
+import com.bttf.queosk.entity.User;
+import com.bttf.queosk.exception.CustomException;
+import com.bttf.queosk.repository.RefreshTokenRepository;
+import com.bttf.queosk.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+class UserServiceTest {
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private RefreshTokenRepository refreshTokenRepository;
+    @Mock
+    private BCryptPasswordEncoder passwordEncoder;
+    @Mock
+    private JwtTokenProvider jwtTokenProvider;
+
+    private UserService userService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        userService = new UserServiceImpl(userRepository, refreshTokenRepository, passwordEncoder, jwtTokenProvider);
+    }
+
+    @Test
+    void testCreateUser() {
+        // Given
+        UserSignUpForm userSignUpForm = UserSignUpForm.builder()
+                .email("test@example.com")
+                .nickName("testUser")
+                .password("password")
+                .phone("123-456-7890")
+                .build();
+
+        when(userRepository.findByEmail(any())).thenReturn(Optional.empty());
+        when(passwordEncoder.encode(any())).thenReturn("encryptedPassword");
+        when(passwordEncoder.matches(userSignUpForm.getPassword(),"encryptedPassword"))
+                .thenReturn(true);
+
+        // When
+        userService.createUser(userSignUpForm);
+
+        // Then
+        verify(userRepository, times(1)).findByEmail(eq("test@example.com"));
+        verify(userRepository, times(1)).save(any(User.class));
+    }
+
+    @Test
+    void testCreateUserWithExistingEmail() {
+        // Given
+        UserSignUpForm userSignUpForm =
+                UserSignUpForm.builder()
+                        .email("existing@example.com")
+                        .build();
+
+        when(userRepository.findByEmail(eq("existing@example.com")))
+                .thenReturn(Optional.of(new User()));
+
+        // When and Then
+        assertThatThrownBy(() -> userService.createUser(userSignUpForm))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining("이미 가입된 회원입니다.");
+
+        verify(userRepository, times(1)).findByEmail(eq("existing@example.com"));
+        verify(userRepository, never()).save(any(User.class));
+    }
+}


### PR DESCRIPTION
### 작업 내용
- 사용자 로그인 기능 구현
### 변경 사항(추가시엔 추가사항)
- 사용자의 로그인정보를 입력받아 아이디/비밀번호 를 검증 후 로그인처리
- 응답 body 에 AccessToken/RefreshToken/닉네임/이메일/이미지경로 전달
- 로그인과 동시에 Access/RefreshToken 발행하며, 리프레시토큰은 redis에 저장 
- (key : email / value : RefreshToken)
### 특이 사항
- RefreshToken의 경우 굳이 프론트로 넘길 필요성 없어보임
- 해당부분(RefreshToken 응답으로 주는부분) 백엔드팀 협의 후 수정필요