### PR TITLE
Feat: RefreshToken 으로 AccessToken 재 발급하는 기능 추가 

### DIFF
--- a/queosk/src/main/java/com/bttf/queosk/config/springSecurity/JwtFilter.java
+++ b/queosk/src/main/java/com/bttf/queosk/config/springSecurity/JwtFilter.java
@@ -34,21 +34,9 @@ public class JwtFilter extends OncePerRequestFilter {
                     .setAuthentication(jwtTokenProvider.getAuthentication(token));
 
         } else if (token != null) {
-            //만약 AccessToken이 유효하지 않을 경우 사용자의 이메일로 RefreshToken 조회
-            String email = jwtTokenProvider.getEmailFromToken(token);
-            String refreshToken = refreshTokenService.getRefreshToken(email);
-
-            //리프레시 토큰이 유효할 경우 , 헤더에 리프레시 토큰 담기
-            if (jwtTokenProvider.validateToken(refreshToken)) {
-                String newAccessToken = refreshTokenService.issueNewAccessToken(email);
-                response.setHeader(HttpHeaders.AUTHORIZATION, newAccessToken);
-                response.setStatus(HttpServletResponse.SC_OK); // 200 Ok
-                response.getWriter().write("토큰이 갱신되었습니다.");
-            } else {
-                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // 401 Unauthorized
-                response.getWriter().write("토큰이 만료되었습니다. 다시 로그인 하세요.");
-                response.getWriter().flush();
-            }
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // 401 Unauthorized
+            response.getWriter().write("엑세스 토큰이 만료되었습니다.");
+            response.getWriter().flush();
         }
         chain.doFilter(request, response);
     }

--- a/queosk/src/main/java/com/bttf/queosk/config/springSecurity/JwtTokenProvider.java
+++ b/queosk/src/main/java/com/bttf/queosk/config/springSecurity/JwtTokenProvider.java
@@ -49,7 +49,8 @@ public class JwtTokenProvider {
                 .setClaims(claims)
                 .setIssuer(issuer)
                 .setIssuedAt(new Date(System.currentTimeMillis()))
-                .setExpiration(new Date(System.currentTimeMillis() + (60 * 60 * 1000)))
+                // 유효기간 1일 (24시간)
+                .setExpiration(new Date(System.currentTimeMillis() + (24 * 60 * 60 * 1000)))
                 .signWith(key)
                 .compact();
     }
@@ -59,7 +60,8 @@ public class JwtTokenProvider {
                 .claim("userRole", UserRole.ROLE_USER.getRoleName())
                 .setIssuer(issuer)
                 .setIssuedAt(new Date(System.currentTimeMillis()))
-                .setExpiration(new Date(System.currentTimeMillis() + (60 * 60 * 1000)))
+                //유효기간 15일 (24시간 *15 )
+                .setExpiration(new Date(System.currentTimeMillis() + (15 * 24 * 60 * 60 * 1000)))
                 .signWith(key)
                 .compact();
     }

--- a/queosk/src/main/java/com/bttf/queosk/controller/RefreshTokenController.java
+++ b/queosk/src/main/java/com/bttf/queosk/controller/RefreshTokenController.java
@@ -1,0 +1,35 @@
+package com.bttf.queosk.controller;
+
+import com.bttf.queosk.dto.tokenDto.NewAccessTokenDto;
+import com.bttf.queosk.dto.tokenDto.RefreshTokenForm;
+import com.bttf.queosk.service.refreshTokenService.RefreshTokenService;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+@RequiredArgsConstructor
+@Api(tags = "Refresh Token API", description = "Refresh Token을 이용해 Access Token을 발급받는 Api")
+@RequestMapping("/api/auth")
+@RestController
+public class RefreshTokenController {
+    private final RefreshTokenService refreshTokenService;
+
+    @PostMapping("/token")
+    @ApiOperation(value = "Access 토큰 재발급", notes = "Refresh토큰을 입력하여 Access Token을 재발급 받습니다.")
+    public ResponseEntity<?> createUser(@Valid @RequestBody RefreshTokenForm refreshTokenForm) {
+
+        NewAccessTokenDto newAccessToken =
+                refreshTokenService.issueNewAccessToken(refreshTokenForm.getRefresh_token());
+
+        return ResponseEntity.status(HttpStatus.OK).body(newAccessToken);
+    }
+
+}

--- a/queosk/src/main/java/com/bttf/queosk/dto/tokenDto/NewAccessTokenDto.java
+++ b/queosk/src/main/java/com/bttf/queosk/dto/tokenDto/NewAccessTokenDto.java
@@ -1,0 +1,14 @@
+package com.bttf.queosk.dto.tokenDto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class NewAccessTokenDto {
+    private String accessToken;
+}

--- a/queosk/src/main/java/com/bttf/queosk/dto/tokenDto/RefreshTokenForm.java
+++ b/queosk/src/main/java/com/bttf/queosk/dto/tokenDto/RefreshTokenForm.java
@@ -1,0 +1,14 @@
+package com.bttf.queosk.dto.tokenDto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class RefreshTokenForm {
+    private String refresh_token;
+}

--- a/queosk/src/main/java/com/bttf/queosk/dto/userDto/UserSignUpForm.java
+++ b/queosk/src/main/java/com/bttf/queosk/dto/userDto/UserSignUpForm.java
@@ -19,11 +19,11 @@ public class UserSignUpForm {
     @NotBlank(message = "이메일은 비워둘 수 없습니다.")
     private String email;
 
-    @Size(min = 4, max = 12, message = "비밀번호는 4~20자 이내로 입력해주세요.")
+    @Size(min = 2, max = 10, message = "닉네임은 2~10자 사이로 입력해주세요.")
     @NotBlank(message = "닉네임은 비워둘 수 없습니다.")
     private String nickName;
 
-    @Size(min = 2, max = 10, message = "닉네임은 2~10자 사이로 입력해주세요.")
+    @Size(min = 4, max = 20, message = "비밀번호는 4~20자 이내로 입력해주세요.")
     @NotBlank(message = "비밀번호는 비워둘 수 없습니다.")
     private String password;
 

--- a/queosk/src/main/java/com/bttf/queosk/entity/RefreshToken.java
+++ b/queosk/src/main/java/com/bttf/queosk/entity/RefreshToken.java
@@ -13,7 +13,7 @@ import org.springframework.data.redis.core.RedisHash;
 @Builder
 @RedisHash(value = "refresh_token")
 public class RefreshToken {
-    @Id
-    private String user_email;
-    private String refresh_token;
+    @Id // 정책변경으로 인해 아이디 email - > token 으로 교체
+    private String token;
+    private String email;
 }

--- a/queosk/src/main/java/com/bttf/queosk/exception/ErrorCode.java
+++ b/queosk/src/main/java/com/bttf/queosk/exception/ErrorCode.java
@@ -22,7 +22,9 @@ public enum ErrorCode {
     // Restaurant 관련 Exception
     INVALID_RESTAURANT(HttpStatus.NOT_FOUND, "존재하지 않는 상점입니다."),
     WITHDRAWN_USER(HttpStatus.BAD_REQUEST,"이미 탈퇴한 회원입니다." ),
-    NOT_VERIFIED_USER(HttpStatus.BAD_REQUEST,"이메일 검증 진행 후 로그인이 가능합니다." );
+    NOT_VERIFIED_USER(HttpStatus.BAD_REQUEST,"이메일 검증 진행 후 로그인이 가능합니다." ),
+    INVALID_REFRESH_TOKEN(HttpStatus.NOT_FOUND,"존재하지 않는 리프레시 토큰입니다." ),
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND,"토큰이 존재하지 않습니다." );
 
 
     private final HttpStatus status;

--- a/queosk/src/main/java/com/bttf/queosk/service/restaurantService/RestaurantService.java
+++ b/queosk/src/main/java/com/bttf/queosk/service/restaurantService/RestaurantService.java
@@ -88,8 +88,8 @@ public class RestaurantService {
 
         refreshTokenRepository.save(
                 RefreshToken.builder()
-                        .user_email(restaurant.getEmail())
-                        .refresh_token(refreshToken)
+                        .email(restaurant.getEmail())
+                        .token(refreshToken)
                         .build()
         );
 

--- a/queosk/src/main/java/com/bttf/queosk/service/userService/UserServiceImpl.java
+++ b/queosk/src/main/java/com/bttf/queosk/service/userService/UserServiceImpl.java
@@ -98,8 +98,8 @@ public class UserServiceImpl implements UserService {
         //리프테시 토큰 저장(기존에 있었다면 덮어쓰기 - 성능상 조회 후 수정보다 덮어쓰기가 더 빠르고 가벼움)
         refreshTokenRepository.save(
                 RefreshToken.builder()
-                        .user_email(user.getEmail())
-                        .refresh_token(refreshToken)
+                        .email(user.getEmail())
+                        .token(refreshToken)
                         .build()
         );
 


### PR DESCRIPTION
### 작업 내용
- AccessToken 만료 시 RefreshToken으로 AccessToken을 재발급 하는 기능 추가
### 변경 사항(추가시엔 추가사항)
- 기존에는 Jwt 필터 내에서 내부적으로 Refresh토큰으로 Access토큰을 재발급하였음. 
- 프론트 팀의 요청으로 별도의 api 제공을 위해 수정. 
### 특이 사항
- 리뷰 자세히 부탁드립니다.