### PR TITLE
Feat: RefreshToken 으로 AccessToken 재 발급하는 기능 추가

### DIFF
--- a/queosk/src/main/java/com/bttf/queosk/config/springSecurity/JwtFilter.java
+++ b/queosk/src/main/java/com/bttf/queosk/config/springSecurity/JwtFilter.java
@@ -1,14 +1,13 @@
 package com.bttf.queosk.config.springSecurity;
 
-import com.bttf.queosk.service.refreshTokenService.RefreshTokenService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
+import org.springframework.util.PatternMatchUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -18,41 +17,41 @@ import java.io.IOException;
 public class JwtFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider jwtTokenProvider;
-    private final RefreshTokenService refreshTokenService;
 
+    private static final String[] ALL_WHITELIST = {
+            "/**/signup",                // 로그인전이므로 AccessToken 체크 패스
+            "/**/signin",                // 로그인전이므로 AccessToken 체크 패스
+            "/**/verification",          // 로그인전이므로 AccessToken 체크 패스
+            "/**/reissue"		         // 토큰갱신이므로 AccessToken 체크 패스
+    };
+
+    //화이트리스트(필터링 대상인지 아닌지 판별)
+    private boolean isFilterCheck(String requestURI){
+        return !PatternMatchUtils.simpleMatch(ALL_WHITELIST, requestURI);
+    }
     @Override
     protected void doFilterInternal(HttpServletRequest request,
-                                    HttpServletResponse response,
-                                    FilterChain chain) throws ServletException, IOException {
+                                   HttpServletResponse response,
+                                   FilterChain chain) throws IOException {
 
         String token = getTokenFromRequest(request);
 
-        if (token != null && jwtTokenProvider.validateToken(token)) {
-
-            SecurityContextHolder
-                    .getContext()
-                    .setAuthentication(jwtTokenProvider.getAuthentication(token));
-
-        } else if (token != null) {
-            //만약 AccessToken이 유효하지 않을 경우 사용자의 이메일로 RefreshToken 조회
-            String email = jwtTokenProvider.getEmailFromToken(token);
-            String refreshToken = refreshTokenService.getRefreshToken(email);
-
-            //리프레시 토큰이 유효할 경우 , 헤더에 리프레시 토큰 담기
-            if (jwtTokenProvider.validateToken(refreshToken)) {
-                String newAccessToken = refreshTokenService.issueNewAccessToken(email);
-                response.setHeader(HttpHeaders.AUTHORIZATION, newAccessToken);
-                response.setStatus(HttpServletResponse.SC_OK); // 200 Ok
-                response.getWriter().write("토큰이 갱신되었습니다.");
-            } else {
-                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // 401 Unauthorized
-                response.getWriter().write("토큰이 만료되었습니다. 다시 로그인 하세요.");
-                response.getWriter().flush();
+        try {
+            // 화이트리스트에 있는 경우에는 필터링을 건너뛰어서 다음 필터로 진행
+            if (isFilterCheck(request.getRequestURI())) {
+                // 화이트리스트에 없는 경우에만 검증 처리
+                if (token != null) {
+                    SecurityContextHolder
+                            .getContext()
+                            .setAuthentication(jwtTokenProvider.getAuthentication(token));
+                }
             }
+            chain.doFilter(request, response);
+        } catch (Exception e) {
+            e.printStackTrace();
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, e.getMessage());
         }
-        chain.doFilter(request, response);
     }
-
     private String getTokenFromRequest(HttpServletRequest request) {
 
         String bearerToken = request.getHeader(HttpHeaders.AUTHORIZATION);

--- a/queosk/src/main/java/com/bttf/queosk/config/springSecurity/JwtTokenProvider.java
+++ b/queosk/src/main/java/com/bttf/queosk/config/springSecurity/JwtTokenProvider.java
@@ -28,9 +28,6 @@ public class JwtTokenProvider {
 
     private final UserDetailsService userDetailsService;
 
-    @Value("${jwt.secretKey}")
-    private String secretKey;
-
     @Value("${jwt.tokenIssuer}")
     private String issuer;
     private SecretKey key;
@@ -49,7 +46,8 @@ public class JwtTokenProvider {
                 .setClaims(claims)
                 .setIssuer(issuer)
                 .setIssuedAt(new Date(System.currentTimeMillis()))
-                .setExpiration(new Date(System.currentTimeMillis() + (60 * 60 * 1000)))
+                // 유효기간 1일 (24시간)
+                .setExpiration(new Date(System.currentTimeMillis() + (24 * 60 * 60 * 1000)))
                 .signWith(key)
                 .compact();
     }
@@ -59,7 +57,8 @@ public class JwtTokenProvider {
                 .claim("userRole", UserRole.ROLE_USER.getRoleName())
                 .setIssuer(issuer)
                 .setIssuedAt(new Date(System.currentTimeMillis()))
-                .setExpiration(new Date(System.currentTimeMillis() + (60 * 60 * 1000)))
+                //유효기간 15일 (24시간 *15 )
+                .setExpiration(new Date(System.currentTimeMillis() + (15 * 24 * 60 * 60 * 1000)))
                 .signWith(key)
                 .compact();
     }

--- a/queosk/src/main/java/com/bttf/queosk/controller/RefreshTokenController.java
+++ b/queosk/src/main/java/com/bttf/queosk/controller/RefreshTokenController.java
@@ -1,0 +1,34 @@
+package com.bttf.queosk.controller;
+
+import com.bttf.queosk.dto.tokenDto.NewAccessTokenDto;
+import com.bttf.queosk.dto.tokenDto.RefreshTokenForm;
+import com.bttf.queosk.service.refreshTokenService.RefreshTokenService;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+
+@RequiredArgsConstructor
+@Api(tags = "Refresh Token API", description = "Refresh Token을 이용해 Access Token을 발급받는 Api")
+@RequestMapping("/api/auth")
+@RestController
+public class RefreshTokenController {
+    private final RefreshTokenService refreshTokenService;
+
+    @PostMapping("/reissue")
+    @ApiOperation(value = "Access 토큰 재발급", notes = "Refresh 토큰을 입력하여 Access Token을 재발급 받습니다.")
+    public ResponseEntity<?> reissueAccessToken(
+            @RequestHeader(HttpHeaders.AUTHORIZATION) String token,
+            @Valid @RequestBody RefreshTokenForm refreshTokenForm) {
+
+        NewAccessTokenDto newAccessTokenDto =
+                refreshTokenService.issueNewAccessToken(refreshTokenForm.getRefresh_token());
+
+        return ResponseEntity.status(HttpStatus.OK).body(newAccessTokenDto);
+    }
+}

--- a/queosk/src/main/java/com/bttf/queosk/dto/tokenDto/NewAccessTokenDto.java
+++ b/queosk/src/main/java/com/bttf/queosk/dto/tokenDto/NewAccessTokenDto.java
@@ -1,0 +1,14 @@
+package com.bttf.queosk.dto.tokenDto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class NewAccessTokenDto {
+    private String accessToken;
+}

--- a/queosk/src/main/java/com/bttf/queosk/dto/tokenDto/RefreshTokenForm.java
+++ b/queosk/src/main/java/com/bttf/queosk/dto/tokenDto/RefreshTokenForm.java
@@ -1,0 +1,14 @@
+package com.bttf.queosk.dto.tokenDto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class RefreshTokenForm {
+    private String refresh_token;
+}

--- a/queosk/src/main/java/com/bttf/queosk/dto/userDto/UserSignOutForm.java
+++ b/queosk/src/main/java/com/bttf/queosk/dto/userDto/UserSignOutForm.java
@@ -1,0 +1,14 @@
+package com.bttf.queosk.dto.userDto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class UserSignOutForm {
+    private String refreshToken;
+}

--- a/queosk/src/main/java/com/bttf/queosk/dto/userDto/UserSignUpForm.java
+++ b/queosk/src/main/java/com/bttf/queosk/dto/userDto/UserSignUpForm.java
@@ -19,11 +19,11 @@ public class UserSignUpForm {
     @NotBlank(message = "이메일은 비워둘 수 없습니다.")
     private String email;
 
-    @Size(min = 4, max = 12, message = "비밀번호는 4~20자 이내로 입력해주세요.")
+    @Size(min = 2, max = 10, message = "닉네임은 2~10자 사이로 입력해주세요.")
     @NotBlank(message = "닉네임은 비워둘 수 없습니다.")
     private String nickName;
 
-    @Size(min = 2, max = 10, message = "닉네임은 2~10자 사이로 입력해주세요.")
+    @Size(min = 4, max = 20, message = "비밀번호는 4~20자 이내로 입력해주세요.")
     @NotBlank(message = "비밀번호는 비워둘 수 없습니다.")
     private String password;
 

--- a/queosk/src/main/java/com/bttf/queosk/entity/RefreshToken.java
+++ b/queosk/src/main/java/com/bttf/queosk/entity/RefreshToken.java
@@ -14,6 +14,6 @@ import org.springframework.data.redis.core.RedisHash;
 @RedisHash(value = "refresh_token")
 public class RefreshToken {
     @Id
-    private String user_email;
-    private String refresh_token;
+    private String token;
+    private String email;
 }

--- a/queosk/src/main/java/com/bttf/queosk/exception/ErrorCode.java
+++ b/queosk/src/main/java/com/bttf/queosk/exception/ErrorCode.java
@@ -16,13 +16,16 @@ public enum ErrorCode {
     PASSWORD_NOT_MATCH(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
     USER_NOT_EXISTS(HttpStatus.NOT_FOUND, "해당 회원을 찾을 수 없습니다."),
     NICKNAME_NOT_MATCH(HttpStatus.BAD_REQUEST,"닉네임 정보가 일치가하지 않습니다." ),
+    WITHDRAWN_USER(HttpStatus.BAD_REQUEST,"이미 탈퇴한 회원입니다." ),
+    NOT_VERIFIED_USER(HttpStatus.BAD_REQUEST,"이메일 검증 진행 후 로그인이 가능합니다." ),
+
+    //Token 관련 Exception
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED,"만료되거나 유효하지 않은 토큰입니다." ),
 
     // Table 관련 Exception
     INVALID_TABLE(HttpStatus.NOT_FOUND, "존재하지 않는 테이블입니다."),
-    // Restaurant 관련 Exception
-    INVALID_RESTAURANT(HttpStatus.NOT_FOUND, "존재하지 않는 상점입니다."),
-    WITHDRAWN_USER(HttpStatus.BAD_REQUEST,"이미 탈퇴한 회원입니다." ),
-    NOT_VERIFIED_USER(HttpStatus.BAD_REQUEST,"이메일 검증 진행 후 로그인이 가능합니다." );
+    // Restaurant 관련 Exception,
+    INVALID_RESTAURANT(HttpStatus.NOT_FOUND, "존재하지 않는 상점입니다.");
 
 
     private final HttpStatus status;

--- a/queosk/src/main/java/com/bttf/queosk/service/refreshTokenService/RefreshTokenService.java
+++ b/queosk/src/main/java/com/bttf/queosk/service/refreshTokenService/RefreshTokenService.java
@@ -1,7 +1,9 @@
 package com.bttf.queosk.service.refreshTokenService;
 
 import com.bttf.queosk.config.springSecurity.JwtTokenProvider;
+import com.bttf.queosk.dto.tokenDto.NewAccessTokenDto;
 import com.bttf.queosk.dto.tokenDto.TokenDto;
+import com.bttf.queosk.entity.RefreshToken;
 import com.bttf.queosk.entity.User;
 import com.bttf.queosk.exception.CustomException;
 import com.bttf.queosk.repository.RefreshTokenRepository;
@@ -9,7 +11,8 @@ import com.bttf.queosk.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import static com.bttf.queosk.exception.ErrorCode.INVALID_USER_ID;
+import static com.bttf.queosk.exception.ErrorCode.INVALID_TOKEN;
+import static com.bttf.queosk.exception.ErrorCode.USER_NOT_EXISTS;
 
 @RequiredArgsConstructor
 @Service
@@ -18,24 +21,29 @@ public class RefreshTokenService {
     private final UserRepository userRepository;
     private final JwtTokenProvider jwtTokenProvider;
 
-    // 고객 이메일로 리프레시 토큰 리턴
-    public String getRefreshToken(String email) {
-        return refreshTokenRepository.findByUserEmail(email);
-    }
-
     // 신규 AccessToken 발급
-    public String issueNewAccessToken(String email) {
-        User user = userRepository.findByEmail(email)
-                .orElseThrow(() -> new CustomException(INVALID_USER_ID));
+    public NewAccessTokenDto issueNewAccessToken(String refreshToken) {
 
-        return jwtTokenProvider.generateAccessToken(
+        if (!jwtTokenProvider.validateToken(refreshToken)) {
+            throw new CustomException(INVALID_TOKEN);
+        }
+
+        RefreshToken token = refreshTokenRepository.findById(refreshToken)
+                .orElseThrow(() -> new CustomException(INVALID_TOKEN));
+
+        User user = userRepository.findByEmail(token.getEmail())
+                .orElseThrow(() -> new CustomException(USER_NOT_EXISTS));
+
+        String newAccessToken = jwtTokenProvider.generateAccessToken(
                 TokenDto.builder()
                         .id(user.getId())
                         .userRole(user.getUserRole())
                         .email(user.getEmail())
                         .build()
         );
+        return NewAccessTokenDto.builder().accessToken(newAccessToken).build();
     }
+
     public void deleteRefreshToken(String email) {
         refreshTokenRepository.deleteById(email);
     }

--- a/queosk/src/main/java/com/bttf/queosk/service/restaurantService/RestaurantService.java
+++ b/queosk/src/main/java/com/bttf/queosk/service/restaurantService/RestaurantService.java
@@ -88,8 +88,8 @@ public class RestaurantService {
 
         refreshTokenRepository.save(
                 RefreshToken.builder()
-                        .user_email(restaurant.getEmail())
-                        .refresh_token(refreshToken)
+                        .email(restaurant.getEmail())
+                        .token(refreshToken)
                         .build()
         );
 

--- a/queosk/src/main/java/com/bttf/queosk/service/userService/UserServiceImpl.java
+++ b/queosk/src/main/java/com/bttf/queosk/service/userService/UserServiceImpl.java
@@ -98,8 +98,8 @@ public class UserServiceImpl implements UserService {
         //리프테시 토큰 저장(기존에 있었다면 덮어쓰기 - 성능상 조회 후 수정보다 덮어쓰기가 더 빠르고 가벼움)
         refreshTokenRepository.save(
                 RefreshToken.builder()
-                        .user_email(user.getEmail())
-                        .refresh_token(refreshToken)
+                        .email(user.getEmail())
+                        .token(refreshToken)
                         .build()
         );
 


### PR DESCRIPTION
### 작업 내용
- AccessToken 만료 시 RefreshToken으로 AccessToken을 재발급 하는 기능 추가
### 변경 사항(추가시엔 추가사항)
- 기존에는 Jwt 필터 내에서 내부적으로 Refresh토큰으로 Access토큰을 재발급하였음. 해당 로직 제거 후 별도 재발급 api 추가
- Redis 의 refresh_token 테이블의 키 를 email -> 토큰 으로 변경
- AccessToken 24시간 , RefreshToken 360시간(15일) 로 만료시간 수정
### 특이 사항
- 리뷰 자세히 부탁드립니다.