### PR TITLE
Feat: User/Restaurant 엑세스토큰 재발급 api 통합

### DIFF
--- a/queosk/src/main/java/com/bttf/queosk/config/springsecurity/JwtFilter.java
+++ b/queosk/src/main/java/com/bttf/queosk/config/springsecurity/JwtFilter.java
@@ -22,7 +22,7 @@ public class JwtFilter extends OncePerRequestFilter {
             "/**/signup",                // 로그인전이므로 AccessToken 체크 패스
             "/**/signin",                // 로그인전이므로 AccessToken 체크 패스
             "/**/verification",          // 로그인전이므로 AccessToken 체크 패스
-            "/**/reissue",		         // 토큰갱신이므로 AccessToken 체크 패스
+            "/**/refresh",		         // 토큰갱신이므로 AccessToken 체크 패스
             "/**/callback"               // 외부 api 콜백이므로 AccessToken 체크 패스
     };
 

--- a/queosk/src/main/java/com/bttf/queosk/config/springsecurity/JwtTokenProvider.java
+++ b/queosk/src/main/java/com/bttf/queosk/config/springsecurity/JwtTokenProvider.java
@@ -129,4 +129,18 @@ public class JwtTokenProvider {
                 userDetails, "", authorities
         );
     }
+
+    public String getRoleFromToken(String token) {
+        if (token.startsWith("Bearer ")) {
+            token = token.substring(7);
+        }
+
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+
+        return valueOf(claims.get("userRole", String.class)).getRoleName();
+    }
 }

--- a/queosk/src/main/java/com/bttf/queosk/controller/EmailVerificationController.java
+++ b/queosk/src/main/java/com/bttf/queosk/controller/EmailVerificationController.java
@@ -11,11 +11,12 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 @RequiredArgsConstructor
-@Api(tags = "이메일 인증 API", description = "이메일 인증과 관련된 API")
+@Api(tags = "Email Verification API", description = "이메일 인증과 관련된 API")
 @RequestMapping("/api/users")
 @Controller
 public class EmailVerificationController {
     private final UserInfoService userInfoService;
+
     @GetMapping("/{id}/verification")
     @ApiOperation(value = "사용자 회원인증", notes = "사용자 상태를 '인증' 상태로 변경합니다.")
     public String verifyUser(@PathVariable Long id, Model model) {

--- a/queosk/src/main/java/com/bttf/queosk/controller/RefreshTokenController.java
+++ b/queosk/src/main/java/com/bttf/queosk/controller/RefreshTokenController.java
@@ -9,37 +9,30 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
 
 import javax.validation.Valid;
 
 @RequiredArgsConstructor
 @Api(tags = "Refresh Token API", description = "Refresh Token을 이용해 Access Token을 발급받는 Api")
-@RequestMapping("/api")
 @RestController
 public class RefreshTokenController {
     private final RefreshTokenService refreshTokenService;
 
-    @PostMapping("/users/auth/reissue")
+    @PostMapping("/api/auth/refresh")
     @ApiOperation(value = "Access 토큰 재발급(고객)", notes = "Refresh 토큰을 입력하여 Access Token을 재발급 받습니다.")
     public ResponseEntity<?> reissueAccessTokenForUser(
             @RequestHeader(HttpHeaders.AUTHORIZATION) String token,
             @Valid @RequestBody RefreshTokenForm refreshTokenForm) {
 
+        String refreshToken = refreshTokenForm.getRefresh_token();
+
+        // 토큰 재발급 서비스 호출
         NewAccessTokenDto newAccessTokenDto =
-                refreshTokenService.issueNewAccessTokenForUser(refreshTokenForm.getRefresh_token());
-
-        return ResponseEntity.status(HttpStatus.OK).body(newAccessTokenDto);
-    }
-
-    @PostMapping("/restaurant/auth/reissue")
-    @ApiOperation(value = "Access 토큰 재발급(점주)", notes = "Refresh 토큰을 입력하여 Access Token을 재발급 받습니다.")
-    public ResponseEntity<?> reissueAccessTokenForRestaurant(
-            @RequestHeader(HttpHeaders.AUTHORIZATION) String token,
-            @Valid @RequestBody RefreshTokenForm refreshTokenForm) {
-
-        NewAccessTokenDto newAccessTokenDto =
-                refreshTokenService.issueNewAccessTokenForRestaurant(refreshTokenForm.getRefresh_token());
+                        refreshTokenService.issueNewAccessToken(token, refreshToken);
 
         return ResponseEntity.status(HttpStatus.OK).body(newAccessTokenDto);
     }


### PR DESCRIPTION
### 작업 내용
- 프론트팀 심상훈님의 요청으로 리프레시 토큰을 이용해 엑세스 토큰을 재발급 받는 
  api 를 User/Restaurant 구분없이 통합
### 변경 사항(추가시엔 추가사항)
- JwtProvider에 토큰을 통해 USER_ROLE 클레임을 체크하는 메서드 생성
- RefreshTokenService 내부에서 해당 메서드 사용하여 User/Restaurant 분기처리 후 토큰 재발급

### 특이 사항
- 프론트팀에게서 요청들어온 내용