### PR TITLE
Refactor: 카카오로그인 주소 호출 api 삭제 및 Validation 조건 수정

### DIFF
--- a/src/main/java/com/bttf/queosk/controller/KakaoLoginController.java
+++ b/src/main/java/com/bttf/queosk/controller/KakaoLoginController.java
@@ -20,12 +20,6 @@ import static org.springframework.http.HttpStatus.OK;
 public class KakaoLoginController {
     private final KakaoLoginService kakaoLoginService;
 
-    @GetMapping("/signin")
-    @ApiOperation(value = "카카오톡 소셜 로그인 경로 호출", notes = "카카오톡 로그인 URL을 가져옵니다")
-    public ResponseEntity<?> kakaoLogin() {
-        return ResponseEntity.status(OK).body(kakaoLoginService.getKakaoLoginURL());
-    }
-
     @PostMapping("/signin")
     @ApiOperation(value = "카카오톡 소셜 로그인 코드를 사용하여 로그인진행",
             notes = "카카오톡 로그인 URL을 통해 얻은 code 및 데이터를 사용하여 로그인 또는 회원가입을 진행합니다.")

--- a/src/main/java/com/bttf/queosk/dto/UserSignInForm.java
+++ b/src/main/java/com/bttf/queosk/dto/UserSignInForm.java
@@ -24,7 +24,7 @@ public class UserSignInForm {
         @NotBlank(message = "이메일은 비워둘 수 없습니다.")
         private String email;
 
-        @Size(min = 2, max = 10, message = "닉네임은 2~10자 사이로 입력해주세요.")
+        @Size(min = 4, max = 20, message = "비밀번호는 4~20자 이내로 입력해주세요.")
         @NotBlank(message = "비밀번호는 비워둘 수 없습니다.")
         private String password;
     }

--- a/src/main/java/com/bttf/queosk/service/KakaoLoginService.java
+++ b/src/main/java/com/bttf/queosk/service/KakaoLoginService.java
@@ -47,13 +47,6 @@ public class KakaoLoginService {
     @Value("${kakao.redirectUrl}")
     private String KAKAO_REDIRECT_URL;
 
-    public String getKakaoLoginURL() {
-        return KAKAO_AUTH_URI + "/oauth/authorize"
-                + "?client_id=" + KAKAO_CLIENT_ID
-                + "&redirect_uri=" + KAKAO_REDIRECT_URL
-                + "&response_type=code";
-    }
-
     public void logoutKakaoUser(String email) {
         KakaoAuth kakaoAuth = kakaoAuthRepository.findById(email);
 


### PR DESCRIPTION
### 작업 내용
- 카카오로그인 경로를 전달하는 api 삭제 
- 로그인 입력값 검증 수정
### 변경 사항(추가시엔 추가사항)
- 카카오로그인 경로를 전달하는 api 삭제 -> 프론트단에서 처리
- 비밀번호 validation 수정
  - AS-IS : `@Size(min = 2, max = 10, message = "닉네임은 2~10자 사이로 입력해주세요.")`
  - TO-BE : `@Size(min = 4, max = 20, message = "비밀번호는 4~20자 이내로 입력해주세요.")`
### 특이 사항
없습니다. 리뷰 잘 부탁드립니다.
### 관련 이슈(옵셔널)
#115 