### PR TITLE
Feat: 좌표 기반 매장 리스트 검색 API를 Dto가 아닌 파라메터를 받도록 수정

### DIFF
--- a/src/main/java/com/bttf/queosk/controller/RestaurantController.java
+++ b/src/main/java/com/bttf/queosk/controller/RestaurantController.java
@@ -106,8 +106,11 @@ public class RestaurantController {
 
     @GetMapping("/coord")
     @ApiOperation(value = "동네 매장 검색 (좌표)", notes = "해당 좌표가 위치한 동네의 매장 리스트를 제공합니다.")
-    public ResponseEntity<Page<RestaurantInfoGetCoordForm.Response>> getCoordRestaurantInfo(@RequestBody RestaurantInfoGetCoordForm.Request restaurantInfoGetCoordForm) {
-        Page<RestaurantDto> restaurantDtoPage = restaurantService.getCoordRestaurantInfoForm(restaurantInfoGetCoordForm);
+    public ResponseEntity<Page<RestaurantInfoGetCoordForm.Response>> getCoordRestaurantInfo(@RequestParam("x") Double x,
+                                                                                            @RequestParam("y") Double y,
+                                                                                            @RequestParam("page") int page,
+                                                                                            @RequestParam("size") int size) {
+        Page<RestaurantDto> restaurantDtoPage = restaurantService.getCoordRestaurantInfoForm(x, y, page, size);
         Page<RestaurantInfoGetCoordForm.Response> responsePage = restaurantDtoPage.map(RestaurantInfoGetCoordForm.Response::of);
         return ResponseEntity.status(OK).body(responsePage);
     }

--- a/src/main/java/com/bttf/queosk/enumerate/RestaurantCategory.java
+++ b/src/main/java/com/bttf/queosk/enumerate/RestaurantCategory.java
@@ -2,17 +2,8 @@ package com.bttf.queosk.enumerate;
 
 
 public enum RestaurantCategory {
-    DONKASU_SUSHI_JAPANESE,
+    JAPANESE,
     CHINESE,
-    CHICKEN,
-    RICE_PORRIDGE_NOODLES,
-    CAFE_DESSERT,
-    STREET_FOOD,
-    STEW_SOUP_HOTPOT,
-    PIZZA,
-    WESTERN,
-    BBQ,
-    JOKBAL_BOSSAM,
-    ASIAN,
-    BURGER
+    KOREAN,
+    WESTERN
 }

--- a/src/main/java/com/bttf/queosk/enumerate/RestaurantCategory.java
+++ b/src/main/java/com/bttf/queosk/enumerate/RestaurantCategory.java
@@ -5,5 +5,6 @@ public enum RestaurantCategory {
     JAPANESE,
     CHINESE,
     KOREAN,
-    WESTERN
+    WESTERN,
+    ETC
 }

--- a/src/main/java/com/bttf/queosk/service/RestaurantService.java
+++ b/src/main/java/com/bttf/queosk/service/RestaurantService.java
@@ -184,10 +184,8 @@ public class RestaurantService {
         return RestaurantDto.of(restaurant);
     }
 
-    public Page<RestaurantDto> getCoordRestaurantInfoForm(RestaurantInfoGetCoordForm.Request restaurantInfoGetCoordRequest) {
-        Pageable pageable = PageRequest.of(restaurantInfoGetCoordRequest.getPage(), restaurantInfoGetCoordRequest.getSize());
-        double x = restaurantInfoGetCoordRequest.getX();
-        double y = restaurantInfoGetCoordRequest.getY();
+    public Page<RestaurantDto> getCoordRestaurantInfoForm(Double x, Double y, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
 
         return restaurantRepository
                 .getRestaurantListByDistance(kakaoGeoAddressService.coordinateToZone(x, y), x, y, pageable)


### PR DESCRIPTION
### 작업 내용
좌표 기반 매장 리스트 검색 API를 Dto가 아닌 파라메터를 받도록 수정

### 변경 사항(추가시엔 추가사항)
좌표 기반 매장 리스트 검색 API를 Dto가 아닌 파라메터를 받도록 수정

### 특이 사항
PR을 리뷰하면서 주의해야 할 사항이나 특이한 부분

### 관련 이슈(옵셔널)
이 PR과 관련된 이슈 번호