### PR TITLE
Merge: QueueService #146 이슈 수정

### DIFF
--- a/src/main/java/com/bttf/queosk/service/QueueService.java
+++ b/src/main/java/com/bttf/queosk/service/QueueService.java
@@ -81,7 +81,7 @@ public class QueueService {
                 );
 
         // 사용자의 인덱스가 존재하지 않을 경우 (Queue 등록하지 않은상태) 예외 반환
-        if (userQueueIndex < 0) {
+        if (userQueueIndex == null || userQueueIndex < 0) {
             throw new CustomException(QUEUE_DOESNT_EXIST);
         }
 
@@ -132,7 +132,7 @@ public class QueueService {
                             String.valueOf(latestQueue.get().getId())
                     );
 
-            if (userWaitingCount != -1) {
+            if (userWaitingCount != null) {
                 throw new CustomException(QUEUE_ALREADY_EXISTS);
             }
         }


### PR DESCRIPTION
### 작업 내용
- 웨이팅 등록 시도 시 기존 웨이팅 존재여부 확인 할때 
redis에서 null을 반환하여 nullpointException 발생. 
해당 부분 null도 체크해주도록 수정하여 이슈 해결

### 변경 사항(추가시엔 추가사항)
- QueueService 기존 웨이팅 확인 로직 수정

### 특이 사항
- 버그 수정

### 관련 이슈(옵셔널)
- #146 