### PR TITLE
Fix: #146 redis에서 인덱스를 찾지 못할경우 -1이 아닌 null을 반환하는 부분 처리하는 코드 수정 (#147)

### DIFF
--- a/src/main/java/com/bttf/queosk/service/QueueService.java
+++ b/src/main/java/com/bttf/queosk/service/QueueService.java
@@ -81,7 +81,7 @@ public class QueueService {
                 );
 
         // 사용자의 인덱스가 존재하지 않을 경우 (Queue 등록하지 않은상태) 예외 반환
-        if (userQueueIndex < 0) {
+        if (userQueueIndex == null || userQueueIndex < 0) {
             throw new CustomException(QUEUE_DOESNT_EXIST);
         }
 
@@ -132,7 +132,7 @@ public class QueueService {
                             String.valueOf(latestQueue.get().getId())
                     );
 
-            if (userWaitingCount != -1) {
+            if (userWaitingCount != null) {
                 throw new CustomException(QUEUE_ALREADY_EXISTS);
             }
         }


### PR DESCRIPTION
웨이팅 등록 시도 시 기존 웨이팅 존재여부 확인 할때 redis에서 null을 반환하여 nullpointException 발생. 해당 부분 null도 체크해주도록 수정하여 이슈 해결

### 작업 내용
작업 내용을 간략하게 설명

### 변경 사항(추가시엔 추가사항)
변경/추가된 내용을 자세하게 설명

### 특이 사항
PR을 리뷰하면서 주의해야 할 사항이나 특이한 부분

### 관련 이슈(옵셔널)
이 PR과 관련된 이슈 번호