### PR TITLE
Fix: 기간별, 금일 정산 시 동일 메뉴에 대한 내용이 안나오는 부분 수정

### DIFF
--- a/src/main/java/com/bttf/queosk/config/RedisConfig.java
+++ b/src/main/java/com/bttf/queosk/config/RedisConfig.java
@@ -21,35 +21,35 @@ public class RedisConfig {
 
 //    로컬에서 테스트 시 아래를 활성화 하여야 함
 
-    @Value("${spring.redis.host}")
-    private String redisHost;
-
-    @Value("${spring.redis.port}")
-    private int redisPort;
-
-    @Bean
-    public RedisConnectionFactory redisConnectionFactory() {
-        return new LettuceConnectionFactory(redisHost, redisPort);
-    }
-
-// 로컬에서 테스트시 아래를 비활성화 하여야 함
-
-//    @Value("${spring.redis.cluster.nodes}")
-//    private List<String> clusterNodes;
+//    @Value("${spring.redis.host}")
+//    private String redisHost;
+//
+//    @Value("${spring.redis.port}")
+//    private int redisPort;
 //
 //    @Bean
 //    public RedisConnectionFactory redisConnectionFactory() {
-//        RedisClusterConfiguration redisClusterConfiguration = new RedisClusterConfiguration();
-//        clusterNodes.forEach(
-//                node -> {
-//                    String[] url = node.split(":");
-//                    redisClusterConfiguration.clusterNode(url[0], Integer.parseInt(url[1]));
-//                }
-//        );
-//
-//
-//        return new LettuceConnectionFactory(redisClusterConfiguration);
+//        return new LettuceConnectionFactory(redisHost, redisPort);
 //    }
+
+// 로컬에서 테스트시 아래를 비활성화 하여야 함
+
+    @Value("${spring.redis.cluster.nodes}")
+    private List<String> clusterNodes;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisClusterConfiguration redisClusterConfiguration = new RedisClusterConfiguration();
+        clusterNodes.forEach(
+                node -> {
+                    String[] url = node.split(":");
+                    redisClusterConfiguration.clusterNode(url[0], Integer.parseInt(url[1]));
+                }
+        );
+
+
+        return new LettuceConnectionFactory(redisClusterConfiguration);
+    }
 
     //  여기까지 비활성화
 

--- a/src/main/java/com/bttf/queosk/config/RedisConfig.java
+++ b/src/main/java/com/bttf/queosk/config/RedisConfig.java
@@ -21,35 +21,35 @@ public class RedisConfig {
 
 //    로컬에서 테스트 시 아래를 활성화 하여야 함
 
-//    @Value("${spring.redis.host}")
-//    private String redisHost;
-//
-//    @Value("${spring.redis.port}")
-//    private int redisPort;
-//
-//    @Bean
-//    public RedisConnectionFactory redisConnectionFactory() {
-//        return new LettuceConnectionFactory(redisHost, redisPort);
-//    }
+    @Value("${spring.redis.host}")
+    private String redisHost;
 
-// 로컬에서 테스트시 아래를 비활성화 하여야 함
-
-    @Value("${spring.redis.cluster.nodes}")
-    private List<String> clusterNodes;
+    @Value("${spring.redis.port}")
+    private int redisPort;
 
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
-        RedisClusterConfiguration redisClusterConfiguration = new RedisClusterConfiguration();
-        clusterNodes.forEach(
-                node -> {
-                    String[] url = node.split(":");
-                    redisClusterConfiguration.clusterNode(url[0], Integer.parseInt(url[1]));
-                }
-        );
-
-
-        return new LettuceConnectionFactory(redisClusterConfiguration);
+        return new LettuceConnectionFactory(redisHost, redisPort);
     }
+
+// 로컬에서 테스트시 아래를 비활성화 하여야 함
+
+//    @Value("${spring.redis.cluster.nodes}")
+//    private List<String> clusterNodes;
+//
+//    @Bean
+//    public RedisConnectionFactory redisConnectionFactory() {
+//        RedisClusterConfiguration redisClusterConfiguration = new RedisClusterConfiguration();
+//        clusterNodes.forEach(
+//                node -> {
+//                    String[] url = node.split(":");
+//                    redisClusterConfiguration.clusterNode(url[0], Integer.parseInt(url[1]));
+//                }
+//        );
+//
+//
+//        return new LettuceConnectionFactory(redisClusterConfiguration);
+//    }
 
     //  여기까지 비활성화
 

--- a/src/main/java/com/bttf/queosk/repository/SettlementQueryRepositoryImpl.java
+++ b/src/main/java/com/bttf/queosk/repository/SettlementQueryRepositoryImpl.java
@@ -45,11 +45,11 @@ public class SettlementQueryRepositoryImpl implements SettlementQueryRepository 
     }
 
     private List<SettlementDto.OrderdMenu> getOrderdMenus(Long restaurantId, QOrder order, QMenu menu,
-                                                          LocalDateTime startDateTime, LocalDateTime endDateTime) {
+                                                          LocalDateTime startDateTime,
+                                                          LocalDateTime endDateTime) {
         return jpaQueryFactory
                 .select(
-                        Projections.constructor(
-                                SettlementDto.OrderdMenu.class,
+                        Projections.constructor(SettlementDto.OrderdMenu.class,
                                 menu.name,
                                 order.count.sum(),
                                 menu.price

--- a/src/main/java/com/bttf/queosk/repository/SettlementQueryRepositoryImpl.java
+++ b/src/main/java/com/bttf/queosk/repository/SettlementQueryRepositoryImpl.java
@@ -44,7 +44,8 @@ public class SettlementQueryRepositoryImpl implements SettlementQueryRepository 
         return getOrderdMenus(restaurantId, order, menu, startDateTime, endDateTime);
     }
 
-    private List<SettlementDto.OrderdMenu> getOrderdMenus(Long restaurantId, QOrder order, QMenu menu, LocalDateTime startDateTime, LocalDateTime endDateTime) {
+    private List<SettlementDto.OrderdMenu> getOrderdMenus(Long restaurantId, QOrder order, QMenu menu,
+                                                          LocalDateTime startDateTime, LocalDateTime endDateTime) {
         return jpaQueryFactory
                 .select(
                         Projections.constructor(

--- a/src/main/java/com/bttf/queosk/service/SettlementService.java
+++ b/src/main/java/com/bttf/queosk/service/SettlementService.java
@@ -7,7 +7,9 @@ import com.bttf.queosk.repository.SettlementRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 
 @Service
@@ -43,8 +45,12 @@ public class SettlementService {
     public Long periodSettlementPriceGet(Long restaurantId,
                                          LocalDateTime to,
                                          LocalDateTime from) {
+        LocalDateTime startDateTime = LocalDateTime.of(LocalDate.from(from), LocalTime.MIN);
+        LocalDateTime endDateTime = LocalDateTime
+                .of(LocalDate.from(to.plusDays(1)), LocalTime.MIN)
+                .minusNanos(1);
         List<Settlement> settlementList =
-                settlementRepository.findSettlementsByRestaurantInDateRange(restaurantId, to, from);
+                settlementRepository.findSettlementsByRestaurantInDateRange(restaurantId, startDateTime, endDateTime);
 
         long totalPrice = settlementList.stream()
                 .mapToLong(Settlement::getPrice)


### PR DESCRIPTION
### 작업 내용
- 기간별, 금일 정산 시 동일 메뉴에 대한 내용이 안나오는 부분 수정
- Settlement 정산 금액 안나오는 부분 수정

### 변경 사항(추가시엔 추가사항)
- 금일, 기간별 정산하는 SettlementQueryRepositoryImpl 코드에서 menuId로 groupBy 하던 것을 menuName으로 변경
- 기간별 정산 금액 from, to 기간에 대해서, 00:00 ~ 23:59 로 조회 할 수 있게 변경

### 특이 사항
PR을 리뷰하면서 주의해야 할 사항이나 특이한 부분

### 관련 이슈(옵셔널)
이 PR과 관련된 이슈 번호