### PR TITLE
Fix: #159 Queue 대기번호 오류 수정 

### DIFF
--- a/src/main/java/com/bttf/queosk/dto/QueueIndexDto.java
+++ b/src/main/java/com/bttf/queosk/dto/QueueIndexDto.java
@@ -15,8 +15,8 @@ public class QueueIndexDto {
 
     public static QueueIndexDto of(Long userQueueIndex) {
         return QueueIndexDto.builder()
-                .queueRemaining(userQueueIndex)
-                .userQueueIndex(userQueueIndex + 1) // 대기번호의 경우 index + 1
+                .queueRemaining(userQueueIndex-1==0?0:userQueueIndex-1)
+                .userQueueIndex(userQueueIndex)
                 .build();
     }
 }

--- a/src/test/java/com/bttf/queosk/service/QueueServiceTest.java
+++ b/src/test/java/com/bttf/queosk/service/QueueServiceTest.java
@@ -178,7 +178,7 @@ class QueueServiceTest {
         when(queueRepository.findFirstByUserIdAndRestaurantIdOrderByCreatedAtDesc(userId, restaurantId))
                 .thenReturn(Optional.of(queue));
         when(queueRedisRepository.getUserWaitingCount(String.valueOf(restaurantId), "5"))
-                .thenReturn(2L);
+                .thenReturn(3L);
 
 
         // when


### PR DESCRIPTION
### 작업 내용
- Queue 대기번호가 실제 웨이팅 수보다 1씩 높게 나오는 현상 수정
### 변경 사항(추가시엔 추가사항)
- 해당 이슈 확인결과 인덱스를 조회하여 대기번호를 반환할때
 중복하여 +1 하고 있어 발생한 이슈.
 해당 중복코드 삭제로 정상반환 확인

### 특이 사항

### 관련 이슈(옵셔널)
#159 