### PR TITLE
Fix: 이메일 인증 api주소 수정

### DIFF
--- a/src/main/java/com/bttf/queosk/service/UserLoginService.java
+++ b/src/main/java/com/bttf/queosk/service/UserLoginService.java
@@ -49,7 +49,7 @@ public class UserLoginService {
                 "Queosk 이메일 인증",
                 String.format("Queosk에 가입해 주셔서 감사합니다. \n" +
                         "아래 링크를 클릭 하시어 이메일 인증을 완료해주세요.\n" +
-                        "http://localhost:8080/api/users/%d/verification", user.getId()));
+                        "https://queosk.kr/api/users/%d/verification", user.getId()));
     }
 
     @Transactional


### PR DESCRIPTION
### 작업 내용
- 이메일 인증 주소를 localhost -> queosk.kr 로 변경했습니다.

### 변경 사항(추가시엔 추가사항)
- 기존: http://localhost:8080/api/users/%d/verification
- 변경: https://queosk.kr/api/users/%d/verification

### 특이 사항
- 없습니다.