### PR TITLE
Merge: 카카오 소셜 로그인 시 프로필 이미지 가져오는 로직 추가 (#173)

### DIFF
--- a/src/main/java/com/bttf/queosk/config/JwtFilter.java
+++ b/src/main/java/com/bttf/queosk/config/JwtFilter.java
@@ -25,7 +25,8 @@ public class JwtFilter extends OncePerRequestFilter {
             "/api/restaurants/coord",    // 매장 조회 토큰 미검증
             "/api/restaurants/*/details",// 매장 상세보기
             "/**/users/check",           // 이메일 중복확인
-            "/**/callback"               // 외부 api 콜백이므로 AccessToken 체크 패스
+            "/**/callback",              // 외부 api 콜백이므로 AccessToken 체크 패스
+            "/**/signin/test"            // 로컬 로그인 관련
     };
     private final JwtTokenProvider jwtTokenProvider;
 

--- a/src/main/java/com/bttf/queosk/config/SecurityConfig.java
+++ b/src/main/java/com/bttf/queosk/config/SecurityConfig.java
@@ -59,7 +59,8 @@ public class SecurityConfig {
                                 "/swagger-ui/**",                 // 스웨거 관련
                                 "/v2/api-docs",
                                 "/swagger-resources/**",
-                                "/webjars/**"                     // Webjar 관련
+                                "/webjars/**",                    // Webjar 관련
+                                "/**/signin/test"                 // 로그인 관련
                         ).permitAll()
                         //외 모든 경로 검증 실시
                         .anyRequest().authenticated()

--- a/src/main/java/com/bttf/queosk/controller/KakaoLoginController.java
+++ b/src/main/java/com/bttf/queosk/controller/KakaoLoginController.java
@@ -34,4 +34,17 @@ public class KakaoLoginController {
 
         return ResponseEntity.status(OK).body(KakaoLoginForm.Response.of(userSignInDto));
     }
+
+    //카카오 소셜로그인 임시 api
+    @PostMapping("/signin/test")
+    @ApiOperation(value = "카카오톡 소셜 로그인 코드를 사용하여 로그인진행(임시)",
+            notes = "카카오톡 로그인 URL을 통해 얻은 code 및 데이터를 사용하여 로그인 또는 회원가입을 진행합니다.")
+    public ResponseEntity<?> kakaoLoginCallbackTest(
+            @Valid @RequestBody KakaoLoginForm.Request kaKaoLoginRequest) {
+
+        UserSignInDto userSignInDto =
+                kakaoLoginService.getUserInfoFromKakaoTest(kaKaoLoginRequest);
+
+        return ResponseEntity.status(OK).body(KakaoLoginForm.Response.of(userSignInDto));
+    }
 }

--- a/src/main/java/com/bttf/queosk/entity/User.java
+++ b/src/main/java/com/bttf/queosk/entity/User.java
@@ -65,7 +65,7 @@ public class User extends BaseTimeEntity {
                 .build();
     }
 
-    public static User of(String email, String nickName, String encodedPassword) {
+    public static User of(String email, String nickName, String encodedPassword, String imageUrl) {
         return User.builder()
                 .email(email)
                 .password(encodedPassword)
@@ -73,6 +73,7 @@ public class User extends BaseTimeEntity {
                 .loginType(KAKAO)
                 .phone("01000000000") // 임시 조치
                 .userRole(ROLE_USER)
+                .imageUrl(imageUrl.contains("https")?imageUrl:imageUrl.replace("http","https"))
                 .status(VERIFIED)
                 .build();
     }


### PR DESCRIPTION
* Feat: 메뉴목록 캐싱을 추가하여 성능향상 및 db부하 감소

메뉴 목록에 대한 캐싱 기능을 추가했습니다.
데이터베이스 쿼리 횟수가 줄고 응답 시간이 개선되었습니다.
'menuList'라는 이름의 캐시를 사용하여 데이터를 저장하고
업데이트 , 삭제 시 캐시도 삭제합니다.

* Feat: 테이블목록 캐싱을 추가하여 성능향상 및 db부하 감소

테이블 목록에 대한 캐싱 기능을 추가했습니다.
데이터베이스 쿼리 횟수가 줄고 응답 시간이 개선되었습니다.
'tableList'라는 이름의 캐시를 사용하여 데이터를 저장하고
업데이트 , 삭제 시 캐시도 삭제합니다.

* Feat: 리뷰목록 캐싱을 추가하여 성능향상 및 db부하 감소

리뷰 목록에 대한 캐싱 기능을 추가했습니다.
데이터베이스 쿼리 횟수가 줄고 응답 시간이 개선되었습니다.
'reviewList'라는 이름의 캐시를 사용하여 데이터를 저장하고
업데이트 , 삭제 시 캐시도 삭제합니다.

* Feat: 캐시 만료시간 설정 (24시간)

* Style: 가독성 향상을 위한 코드 formatting 수정

* Refactor: 원활한 유지보수를 위한 메서드 분리 및 기타 코드 리팩터링

* Feat: 카카오 소셜 로그인 관련 두 개의 redirect_url 를 사용하도록 수정

* Feat: SecurityConfig 화이트리스트 추가 (로컬로그인)

* Feat: Kakao 소셜 로그인 시 사용자의 카카오프로필 이미지를 받아 회원가입 시 프로필이미지에 추가하도록 로직 수정

### 작업 내용
작업 내용을 간략하게 설명

### 변경 사항(추가시엔 추가사항)
변경/추가된 내용을 자세하게 설명

### 특이 사항
PR을 리뷰하면서 주의해야 할 사항이나 특이한 부분

### 관련 이슈(옵셔널)
이 PR과 관련된 이슈 번호