### PR TITLE
Merge: 카카오소셜 로그인 시 요청 도메인 인터셉트 하여 다른 로직으로 분기 (#175)

### DIFF
--- a/src/main/java/com/bttf/queosk/controller/KakaoLoginController.java
+++ b/src/main/java/com/bttf/queosk/controller/KakaoLoginController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 
 import static org.springframework.http.HttpStatus.OK;
@@ -26,24 +27,16 @@ public class KakaoLoginController {
     @PostMapping("/signin")
     @ApiOperation(value = "카카오톡 소셜 로그인 코드를 사용하여 로그인진행",
             notes = "카카오톡 로그인 URL을 통해 얻은 code 및 데이터를 사용하여 로그인 또는 회원가입을 진행합니다.")
-    public ResponseEntity<?> kakaoLoginCallback(
+    public ResponseEntity<KakaoLoginForm.Response> kakaoLoginCallback(
+            HttpServletRequest request,
             @Valid @RequestBody KakaoLoginForm.Request kaKaoLoginRequest) {
 
-        UserSignInDto userSignInDto =
-                kakaoLoginService.getUserInfoFromKakao(kaKaoLoginRequest);
-
-        return ResponseEntity.status(OK).body(KakaoLoginForm.Response.of(userSignInDto));
-    }
-
-    //카카오 소셜로그인 임시 api
-    @PostMapping("/signin/test")
-    @ApiOperation(value = "카카오톡 소셜 로그인 코드를 사용하여 로그인진행(임시)",
-            notes = "카카오톡 로그인 URL을 통해 얻은 code 및 데이터를 사용하여 로그인 또는 회원가입을 진행합니다.")
-    public ResponseEntity<?> kakaoLoginCallbackTest(
-            @Valid @RequestBody KakaoLoginForm.Request kaKaoLoginRequest) {
+        String host = request.getHeader("Host");
 
         UserSignInDto userSignInDto =
-                kakaoLoginService.getUserInfoFromKakaoTest(kaKaoLoginRequest);
+            host.contains("localhost")?
+            kakaoLoginService.getUserInfoFromKakaoTest(kaKaoLoginRequest):
+            kakaoLoginService.getUserInfoFromKakao(kaKaoLoginRequest);
 
         return ResponseEntity.status(OK).body(KakaoLoginForm.Response.of(userSignInDto));
     }


### PR DESCRIPTION
카카오 소셜 로그인 redirectURL분기를 위한 수정입니다.
기존 2개의 api를 나누어 호출하던부분을 하나로 통합하고
요청도메인을 컨트롤러에서 가로채 분기하는 로직을 태웠습니다.
try-catch문을 세분화 하여 예외 발생 시 서버로그를 통해 정확한 원인을 찾을 수 있도록 처리했습니다.

### 작업 내용
작업 내용을 간략하게 설명

### 변경 사항(추가시엔 추가사항)
변경/추가된 내용을 자세하게 설명

### 특이 사항
PR을 리뷰하면서 주의해야 할 사항이나 특이한 부분

### 관련 이슈(옵셔널)
이 PR과 관련된 이슈 번호