### PR TITLE
Feat: prefix를 이용한 검색어 자동완성 기능 추가 

### DIFF
--- a/src/main/java/com/bttf/queosk/common/AutoCompleteTrie.java
+++ b/src/main/java/com/bttf/queosk/common/AutoCompleteTrie.java
@@ -1,0 +1,111 @@
+package com.bttf.queosk.common;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@Setter
+class TrieNode {
+    Map<Character, TrieNode> children; // 문자와 자식 TrieNode를 매핑하는 맵
+    boolean isEndOfWord; // 단어의 끝인지 여부를 나타내는 플래그
+
+    TrieNode() {
+        this.children = new HashMap<>();
+        this.isEndOfWord = false;
+    }
+}
+
+@Getter
+@AllArgsConstructor
+@Component
+public class AutoCompleteTrie {
+    private TrieNode root;
+
+    public AutoCompleteTrie() {
+        this.root = new TrieNode();
+    }
+
+    // 단어를 Trie에 삽입하는 메서드
+    public void insert(String word) {
+        TrieNode current = root;
+        for (char c : word.toCharArray()) {
+            if (!current.getChildren().containsKey(c)) {
+                // 현재 문자 노드에 해당 문자의 자식 노드가 없으면 생성
+                current.getChildren().put(c, new TrieNode());
+            }
+            current = current.getChildren().get(c); // 다음 레벨의 노드로 이동
+        }
+        current.setEndOfWord(true); // 마지막 문자까지 삽입한 후에 단어의 끝 플래그를 설정
+    }
+
+
+    // 주어진 접두사(prefix)로 시작하는 단어를 검색하여 추천 리스트를 반환하는 메서드
+    public List<String> autoComplete(String prefix) {
+        TrieNode current = root;
+        List<String> suggestions = new ArrayList<>();
+
+        // prefix를 Trie에서 찾으면서 현재 노드를 업데이트
+        for (char c : prefix.toCharArray()) {
+            current = current.getChildren().get(c);
+            if (current == null) {
+                return suggestions; // 접두사(prefix)가 존재하지 않으면 빈 리스트 반환
+            }
+        }
+
+        // 접두사(prefix)로 시작하는 모든 단어를 찾아 추천 리스트에 추가
+        findWordsWithPrefix(current, prefix, suggestions);
+
+        return suggestions;
+    }
+
+    // 접두사(prefix)로 시작하는 모든 단어를 검색하여 추천 리스트에 추가하는 재귀함수
+    private void findWordsWithPrefix(TrieNode node, String prefix, List<String> results) {
+        if (node.isEndOfWord()) {
+            results.add(prefix); // 현재 노드가 단어의 끝인 경우, 추천 리스트에 추가
+        }
+        node.getChildren().forEach((c, child) -> {
+            findWordsWithPrefix(child, prefix + c, results); // 모든 자식 노드에 대해 재귀적으로 검색 수행
+        });
+    }
+
+    // 입력된 단어만을 삭제하는 메서드
+    public void delete(String word) {
+        delete(root, word, 0);
+    }
+
+    private boolean delete(TrieNode node, String word, int index) {
+        if (index == word.length()) {
+            // 단어의 마지막 문자까지 도달했을 때
+            if (!node.isEndOfWord) {
+                // 해당 단어가 Trie에 존재하지 않으면 삭제할 필요가 없음
+                return false;
+            }
+            node.isEndOfWord = false; // 단어의 끝을 표시하는 플래그를 false로 설정
+            return node.children.isEmpty(); // 자식 노드가 없으면 해당 노드도 삭제해야 함
+        }
+
+        char c = word.charAt(index);
+        TrieNode child = node.children.get(c);
+        if (child == null) {
+            // 단어의 문자가 Trie에 존재하지 않으면 삭제할 필요가 없음
+            return false;
+        }
+
+        boolean shouldDeleteChild = delete(child, word, index + 1);
+
+        if (shouldDeleteChild) {
+            // 자식 노드가 삭제될 경우, 현재 노드의 children 맵에서도 제거
+            node.children.remove(c);
+            // 현재 노드에 다른 단어가 연결되어 있지 않으면 현재 노드도 삭제
+            return node.children.isEmpty() && !node.isEndOfWord;
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/bttf/queosk/config/JwtFilter.java
+++ b/src/main/java/com/bttf/queosk/config/JwtFilter.java
@@ -26,6 +26,7 @@ public class JwtFilter extends OncePerRequestFilter {
             "/api/restaurants/*/details",// 매장 상세보기
             "/**/users/check",           // 이메일 중복확인
             "/**/callback",              // 외부 api 콜백이므로 AccessToken 체크 패스
+            "/**/autocomplete"           // 매장검색어 자동완성
     };
     private final JwtTokenProvider jwtTokenProvider;
 

--- a/src/main/java/com/bttf/queosk/config/SecurityConfig.java
+++ b/src/main/java/com/bttf/queosk/config/SecurityConfig.java
@@ -59,7 +59,8 @@ public class SecurityConfig {
                                 "/swagger-ui/**",                 // 스웨거 관련
                                 "/v2/api-docs",
                                 "/swagger-resources/**",
-                                "/webjars/**"                     // Webjar 관련
+                                "/webjars/**",                     // Webjar 관련
+                                "/api/autocomplete"               // 매장검색어 자동완성
                         ).permitAll()
                         //외 모든 경로 검증 실시
                         .anyRequest().authenticated()

--- a/src/main/java/com/bttf/queosk/controller/AutoCompleteController.java
+++ b/src/main/java/com/bttf/queosk/controller/AutoCompleteController.java
@@ -1,0 +1,34 @@
+package com.bttf.queosk.controller;
+
+import com.bttf.queosk.dto.AutoCompleteDto;
+import com.bttf.queosk.dto.AutoCompleteResponse;
+import com.bttf.queosk.service.AutoCompleteService;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import static org.springframework.http.HttpStatus.OK;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/autocomplete")
+@Api(tags = "Auto-Complete API", description = "검색어 자동완성 리스트 조회 API")
+@RestController
+public class AutoCompleteController {
+
+    private final AutoCompleteService autoCompleteService;
+
+    @GetMapping
+    @ApiOperation(value = "검색어 자동완성", notes = "주어진 prefix 로 식당이름을 자동완성합니다.")
+    public ResponseEntity<AutoCompleteResponse> autoComplete(
+            @RequestParam String prefix) {
+        AutoCompleteDto autoCompleteDto = autoCompleteService.autoComplete(prefix);
+        return ResponseEntity.status(OK).body(AutoCompleteResponse.of(autoCompleteDto));
+    }
+}
+
+

--- a/src/main/java/com/bttf/queosk/controller/RestaurantController.java
+++ b/src/main/java/com/bttf/queosk/controller/RestaurantController.java
@@ -3,6 +3,7 @@ package com.bttf.queosk.controller;
 import com.bttf.queosk.config.JwtTokenProvider;
 import com.bttf.queosk.dto.*;
 import com.bttf.queosk.enumerate.RestaurantCategory;
+import com.bttf.queosk.service.AutoCompleteService;
 import com.bttf.queosk.service.RefreshTokenService;
 import com.bttf.queosk.service.RestaurantService;
 import io.swagger.annotations.Api;
@@ -27,6 +28,7 @@ public class RestaurantController {
 
     private final RestaurantService restaurantService;
     private final RefreshTokenService refreshTokenService;
+    private final AutoCompleteService autoCompleteService;
     private final JwtTokenProvider jwtTokenProvider;
 
     @PostMapping("/signup")
@@ -34,7 +36,7 @@ public class RestaurantController {
     public ResponseEntity<Void> signUp(
             @Valid @RequestBody RestaurantSignUpForm.Request restaurantSignUpRequest) throws Exception {
         restaurantService.signUp(restaurantSignUpRequest);
-
+        autoCompleteService.saveKeyword(restaurantSignUpRequest.getRestaurantName());
         return ResponseEntity.status(CREATED).build();
     }
 
@@ -95,6 +97,8 @@ public class RestaurantController {
     @ApiOperation(value = "사업자 탈퇴", notes = "매장 계정을 삭제합니다.")
     public ResponseEntity<Void> deleteRestaurant(@RequestHeader(HttpHeaders.AUTHORIZATION) String token) {
         restaurantService.deleteRestaurant(token);
+        Long restaurantId = jwtTokenProvider.getIdFromToken(token);
+        autoCompleteService.deleteRestaurantName(restaurantId);
         return ResponseEntity.status(NO_CONTENT).build();
     }
 

--- a/src/main/java/com/bttf/queosk/dto/AutoCompleteDto.java
+++ b/src/main/java/com/bttf/queosk/dto/AutoCompleteDto.java
@@ -1,0 +1,16 @@
+package com.bttf.queosk.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class AutoCompleteDto {
+    private List<String> restaurants;
+}

--- a/src/main/java/com/bttf/queosk/dto/AutoCompleteResponse.java
+++ b/src/main/java/com/bttf/queosk/dto/AutoCompleteResponse.java
@@ -1,0 +1,22 @@
+package com.bttf.queosk.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class AutoCompleteResponse {
+    private List<String> restaurants;
+
+    public static AutoCompleteResponse of(AutoCompleteDto autoCompleteDto){
+        return AutoCompleteResponse.builder()
+                .restaurants(autoCompleteDto.getRestaurants())
+                .build();
+    }
+}

--- a/src/main/java/com/bttf/queosk/repository/RestaurantRepository.java
+++ b/src/main/java/com/bttf/queosk/repository/RestaurantRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -18,4 +19,6 @@ public interface RestaurantRepository extends JpaRepository<Restaurant, Long> {
     Optional<Restaurant> findByOwnerId(String ownerId);
 
     Optional<Restaurant> findByEmail(String email);
+
+    List<Restaurant> findByIsDeleted(boolean trueOrFalse);
 }

--- a/src/main/java/com/bttf/queosk/service/AutoCompleteService.java
+++ b/src/main/java/com/bttf/queosk/service/AutoCompleteService.java
@@ -1,0 +1,51 @@
+package com.bttf.queosk.service;
+
+import com.bttf.queosk.common.AutoCompleteTrie;
+import com.bttf.queosk.dto.AutoCompleteDto;
+import com.bttf.queosk.entity.Restaurant;
+import com.bttf.queosk.repository.RestaurantRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import javax.annotation.PostConstruct;
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class AutoCompleteService {
+
+    private final AutoCompleteTrie autoCompleteTrie;
+
+    private final RestaurantRepository restaurantRepository;
+
+    @PostConstruct
+    public void initTrieWithRestaurantNames() {
+        // 서버 구동 시 한번실행. 가입된 모든 매장의 리스트를 조회하고 AutoCompleteTrie 에 추가
+        List<Restaurant> restaurants = restaurantRepository.findByIsDeleted(false);
+        restaurants.forEach(restaurant -> {
+            autoCompleteTrie.insert(restaurant.getRestaurantName());
+        });
+        log.info("Auto-Complete Registration Completed (List)");
+    }
+
+    // 검색어를 Trie에 추가하는 메서드
+    public void saveKeyword(String keyword) {
+        // Trie에 검색어 추가
+        autoCompleteTrie.insert(keyword);
+        log.info("Auto-Complete Registration Completed (Single)");
+    }
+
+    // 검색어 자동완성 기능을 위한 메서드
+    public AutoCompleteDto autoComplete(String prefix) {
+        return AutoCompleteDto.builder().restaurants(autoCompleteTrie.autoComplete(prefix)).build();
+    }
+
+    // 탈퇴 시 자동검색어완성에서 해당 식당이름을 지우는 메서드
+    public void deleteRestaurantName(Long restaurantId) {
+        restaurantRepository.findById(restaurantId).ifPresent(restaurant -> {
+            autoCompleteTrie.delete(restaurant.getRestaurantName());
+        });
+    }
+}

--- a/src/main/java/com/bttf/queosk/service/AutoCompleteService.java
+++ b/src/main/java/com/bttf/queosk/service/AutoCompleteService.java
@@ -9,6 +9,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import javax.annotation.PostConstruct;
+import java.util.Arrays;
 import java.util.List;
 
 @Slf4j
@@ -19,6 +20,13 @@ public class AutoCompleteService {
     private final AutoCompleteTrie autoCompleteTrie;
 
     private final RestaurantRepository restaurantRepository;
+
+    private final List<String> consonantsAndVowels = Arrays.asList(
+            "ㄱ", "ㄲ", "ㄴ", "ㄷ", "ㄸ", "ㄹ", "ㅁ", "ㅂ", "ㅃ", "ㅅ",
+            "ㅆ", "ㅇ", "ㅈ", "ㅉ", "ㅊ", "ㅋ", "ㅌ", "ㅍ", "ㅎ",
+            "ㅏ", "ㅐ", "ㅑ", "ㅒ", "ㅓ", "ㅔ", "ㅕ", "ㅖ", "ㅗ", "ㅘ",
+            "ㅙ", "ㅚ", "ㅛ", "ㅜ", "ㅝ", "ㅞ", "ㅟ", "ㅠ", "ㅡ", "ㅢ", "ㅣ"
+    );
 
     @PostConstruct
     public void initTrieWithRestaurantNames() {
@@ -39,7 +47,10 @@ public class AutoCompleteService {
 
     // 검색어 자동완성 기능을 위한 메서드
     public AutoCompleteDto autoComplete(String prefix) {
-        return AutoCompleteDto.builder().restaurants(autoCompleteTrie.autoComplete(prefix)).build();
+        String afterTrimming = removeKoreanConsonantsAndVowels(prefix).trim();
+        return AutoCompleteDto.builder()
+                .restaurants(autoCompleteTrie.autoComplete(afterTrimming))
+                .build();
     }
 
     // 탈퇴 시 자동검색어완성에서 해당 식당이름을 지우는 메서드
@@ -47,5 +58,12 @@ public class AutoCompleteService {
         restaurantRepository.findById(restaurantId).ifPresent(restaurant -> {
             autoCompleteTrie.delete(restaurant.getRestaurantName());
         });
+    }
+
+    private String removeKoreanConsonantsAndVowels(String text) {
+        for (String character : consonantsAndVowels) {
+            text = text.replace(character, "");
+        }
+        return text;
     }
 }

--- a/src/test/java/com/bttf/queosk/service/AutoCompleteServiceTest.java
+++ b/src/test/java/com/bttf/queosk/service/AutoCompleteServiceTest.java
@@ -1,0 +1,87 @@
+package com.bttf.queosk.service;
+
+import com.bttf.queosk.common.AutoCompleteTrie;
+import com.bttf.queosk.dto.AutoCompleteDto;
+import com.bttf.queosk.entity.Restaurant;
+import com.bttf.queosk.repository.RestaurantRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+public class AutoCompleteServiceTest {
+    @Mock
+    private AutoCompleteTrie autoCompleteTrie;
+
+    @Mock
+    private RestaurantRepository restaurantRepository;
+
+    private AutoCompleteService autoCompleteService;
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+        autoCompleteService = new AutoCompleteService(autoCompleteTrie, restaurantRepository);
+    }
+
+    @Test
+    @DisplayName("검색어자동완성 생성 테스트 - 성공")
+    public void saveKeywordToTrie() {
+        // Given
+        String keyword = "TestKeyword";
+
+        // When
+        autoCompleteService.saveKeyword(keyword);
+
+        // Then
+        verify(autoCompleteTrie, times(1)).insert(keyword);
+    }
+
+    @Test
+    @DisplayName("검색어자동완성 조회 테스트 - 성공")
+    public void returnAutoCompleteList() {
+        // Given
+        String prefix = "TestPrefix";
+        List<String> autoCompleteList = new ArrayList<>();
+        autoCompleteList.add("TestRestaurant1");
+        autoCompleteList.add("TestRestaurant2");
+
+        when(autoCompleteTrie.autoComplete(prefix)).thenReturn(autoCompleteList);
+
+        // When
+        AutoCompleteDto result = autoCompleteService.autoComplete(prefix);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.getRestaurants()).isEqualTo(autoCompleteList);
+    }
+
+    @Test
+    @DisplayName("검색어자동완성 삭제 테스트 - 성공")
+    public void deleteRestaurantNameFromTrie() {
+        // Given
+        Long restaurantId = 1L;
+        String restaurantName = "TestRestaurant";
+
+        Restaurant restaurant = Restaurant.builder()
+                .id(restaurantId)
+                .restaurantName(restaurantName)
+                .build();
+
+        when(restaurantRepository.findById(restaurantId)).thenReturn(Optional.of(restaurant));
+
+        // When
+        autoCompleteService.deleteRestaurantName(restaurantId);
+
+        // Then
+        verify(autoCompleteTrie, times(1)).delete(restaurantName);
+    }
+}


### PR DESCRIPTION
### 작업 내용
- prefix를 이용한 검색어 자동완성 기능 추가 (trie 자료구조활용)
### 변경 사항(추가시엔 추가사항)
- trie 자료구조를 활용하여 prefix를 이용해 검색어 자동완성 리스트를 반환해주는 기능을 추가했습니다.
- 앱 기동 시 정상가입된 식당들의 전체 목록을 추가하며, 식당회원가입 시 단건추가, 식당회원탈퇴 시 단건 삭제를 진행하도록 구성했습니다.
- 첫글자 혹은 마지막글자에 공백이 들어올 경우 trim() (예: " 김가네분식       ")
- 검색어 작성도중 호출되어 모음 또는 자음 자체가 입력된 경우 (예: "김가ㄴ" , "김가네 분식ㄱ") 해당 모음/자음 문자 제거  후 조회
### 특이 사항
- 이상하게 `@NoArgsConstructor` 를 사용한 기본생성자 생성 시 기본생성자 생성 부분에서 `NullPointException`예외가 발생 하더라구요. 
- 그래서 일단은 기본생성자를 직접 명시적으로 코드로 작성했습니다.
- 혹시 원인을 아시는 분은 리뷰 후 댓글 부탁드립니다.