### PR TITLE
Merge: 검색어 자동완성기능 검색어 접두사/접중사/접미사/초성 모두 검색가능한 기능 구현 (#198)

### DIFF
--- a/src/main/java/com/bttf/queosk/repository/SettlementQueryRepositoryImpl.java
+++ b/src/main/java/com/bttf/queosk/repository/SettlementQueryRepositoryImpl.java
@@ -51,12 +51,12 @@ public class SettlementQueryRepositoryImpl implements SettlementQueryRepository 
                 .select(
                         Projections.constructor(SettlementDto.OrderdMenu.class,
                                 menu.name,
-                                order.count.sum(),
+//                                order.count.sum(),  빌드문제로 인한 임시 주석처리
                                 menu.price
                         )
                 )
                 .from(order)
-                .innerJoin(menu).on(order.menuId.eq(menu.id))
+//                .innerJoin(menu).on(order.menuId.eq(menu.id))  빌드문제로 인한 임시 주석처리
                 .where(order.restaurantId.eq(restaurantId)
                         .and(order.createdAt.between(startDateTime, endDateTime))
                         .and(order.status.eq(OrderStatus.DONE)))

--- a/src/test/java/com/bttf/queosk/service/OrderServiceTest.java
+++ b/src/test/java/com/bttf/queosk/service/OrderServiceTest.java
@@ -7,7 +7,6 @@ import com.bttf.queosk.enumerate.OrderStatus;
 import com.bttf.queosk.enumerate.TableStatus;
 import com.bttf.queosk.repository.*;
 import org.junit.jupiter.api.DisplayName;
-import com.google.api.services.storage.Storage;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -15,9 +14,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 import static com.bttf.queosk.enumerate.MenuStatus.ON_SALE;
@@ -81,22 +77,15 @@ class OrderServiceTest {
                 .email(userEmail)
                 .build();
 
-        MenuItem menuItem = MenuItem.builder()
-                .menu(menu1)
+        OrderCreationForm.Request orderCreationForm = OrderCreationForm.Request.builder()
+                .menuId(menuId)
+                .tableId(tableId)
+                .restaurantId(restaurantId)
                 .count(1)
                 .build();
 
-        List<MenuItem> menuItems = List.of(menuItem);
-
-
-
-        OrderCreationForm.Request orderCreationForm = OrderCreationForm.Request.builder()
-                .menuItems(menuItems)
-                .tableId(tableId)
-                .restaurantId(restaurantId)
-                .build();
-
         given(restaurantRepository.findById(1L)).willReturn(Optional.of(restaurant));
+        given(menuRepository.findByIdAndRestaurantId(1L, 1L)).willReturn(Optional.of(menu1));
         given(tableRepository.findById(1L)).willReturn(Optional.of(table));
         // when
 
@@ -142,6 +131,8 @@ class OrderServiceTest {
 
         Order order = Order.builder()
                 .userId(user.getId())
+                .menuId(menu1.getId())
+                .count(1)
                 .restaurantId(restaurant.getId())
                 .status(OrderStatus.IN_PROGRESS)
                 .build();


### PR DESCRIPTION
### 작업 내용
- 검색어 자동완성기능 검색어 접두사/접중사/접미사/초성 모두 검색가능한 기능 구현 
- Swagger 문서화를 위한 어노테이션 추가 (DTO)
- 유닛테스트 `@DisplayName` 추가로 테스트 목적 명시
### 변경 사항(추가시엔 추가사항)
- 검색어 자동완성기능 
   - 기존 메모리의 trie 자료구조를 사용함에 있어 몇몇 기능에 한계가 있음을 확인
   - Redis 를 이용하여 크게 차이나지 않는 성능으로 다양한 기능 구현
- 유닛테스트 테스트목적 명시
  - 기존 메서드 별 DisplayName 외에도 클래스별 DisplayName을 사용해
테스트 목적을 좀더 명확히 함.
- Swagger 문서화를 위한 DTO 어노테이션(ApiModel) 추가

### 특이 사항
- 충돌로 인한 버전 다운그레이드 - #192 
- @jodonghyeon3 빌드이슈로 인한 코드 주석처리 -SettlementQueryRepositoryImpl.java / 54번째, 59번째 줄