### PR TITLE
Feat: 정산 시 구매된 각 메뉴의 가격도 함께 반환하도록 수정

### DIFF
--- a/src/main/java/com/bttf/queosk/config/SecurityConfig.java
+++ b/src/main/java/com/bttf/queosk/config/SecurityConfig.java
@@ -58,6 +58,7 @@ public class SecurityConfig {
                                 "/api/restaurants/keyword",       // 매장 조회 (키워드)
                                 "/api/restaurants/*/menus",       // 매장 메뉴 조회
                                 "/api/restaurants/*/details",     // 매장 상세조회
+                                "/api/reviews/restaurants/**",     // 매장 리뷰 조회
                                 "/swagger-ui/**",                 // 스웨거 관련
                                 "/v2/api-docs",
                                 "/swagger-resources/**",

--- a/src/main/java/com/bttf/queosk/controller/SettlementController.java
+++ b/src/main/java/com/bttf/queosk/controller/SettlementController.java
@@ -1,8 +1,8 @@
 package com.bttf.queosk.controller;
 
 import com.bttf.queosk.config.JwtTokenProvider;
-import com.bttf.queosk.dto.SettlementResponseForm;
 import com.bttf.queosk.dto.SettlementPriceForm;
+import com.bttf.queosk.dto.SettlementResponseForm;
 import com.bttf.queosk.service.SettlementService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -34,14 +34,10 @@ public class SettlementController {
         Long restaurantId = jwtTokenProvider.getIdFromToken(token);
 
         LocalDate today = LocalDate.now();
-        LocalDateTime from = LocalDateTime.of(today, LocalTime.MIN);
-        LocalDateTime to = LocalDateTime
-                .of(today.plusDays(1), LocalTime.MIN)
-                .minusNanos(1);
 
         return ResponseEntity.status(OK)
                 .body(SettlementResponseForm.of(settlementService.SettlementGet(
-                        restaurantId, from, to
+                        restaurantId, getLocalDateTimeOfFrom(today), getLocalDateTimeOfTo(today)
                 )));
     }
 
@@ -52,11 +48,11 @@ public class SettlementController {
             @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate to,
             @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate from) {
 
-
         Long restaurantId = jwtTokenProvider.getIdFromToken(token);
+
         return ResponseEntity.status(OK)
                 .body(SettlementResponseForm.of(settlementService.SettlementGet(
-                        restaurantId, to.atStartOfDay(), from.atStartOfDay()
+                        restaurantId, getLocalDateTimeOfTo(from), getLocalDateTimeOfTo(to)
                 )));
     }
 
@@ -71,7 +67,15 @@ public class SettlementController {
 
         return ResponseEntity.status(OK)
                 .body(SettlementPriceForm.Response.of(settlementService.periodSettlementPriceGet(
-                        restaurantId, to.atStartOfDay(), from.atStartOfDay()
+                        restaurantId, getLocalDateTimeOfTo(from), getLocalDateTimeOfTo(to)
                 )));
+    }
+
+    private LocalDateTime getLocalDateTimeOfTo(LocalDate localDate) {
+        return LocalDateTime.of(localDate, LocalTime.MAX);
+    }
+
+    private LocalDateTime getLocalDateTimeOfFrom(LocalDate localDate) {
+        return LocalDateTime.of(localDate, LocalTime.MIN);
     }
 }

--- a/src/main/java/com/bttf/queosk/dto/MenuItemDto.java
+++ b/src/main/java/com/bttf/queosk/dto/MenuItemDto.java
@@ -1,0 +1,32 @@
+package com.bttf.queosk.dto;
+
+import com.bttf.queosk.entity.MenuItem;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class MenuItemDto {
+    private Long menuPrice;
+    private Integer count;
+
+    public static MenuItemDto of(MenuItem menuItem){
+        return MenuItemDto.builder()
+                .menuPrice(menuItem.getMenu().getPrice())
+                .count(menuItem.getCount())
+                .build();
+    }
+
+    public MenuItemDto(Long menuPrice){
+        this.menuPrice = menuPrice;
+        this.count = 0;
+    }
+    public MenuItemDto addCount(int countToAdd) {
+        this.count += countToAdd;
+        return this;
+    }
+}

--- a/src/main/java/com/bttf/queosk/dto/SettlementDto.java
+++ b/src/main/java/com/bttf/queosk/dto/SettlementDto.java
@@ -31,6 +31,7 @@ public class SettlementDto {
     @AllArgsConstructor
     public static class OrderdMenu {
         private String menu;
+        private Long menuPrice;
         private Integer count;
     }
 }

--- a/src/main/java/com/bttf/queosk/dto/SettlementResponseForm.java
+++ b/src/main/java/com/bttf/queosk/dto/SettlementResponseForm.java
@@ -36,11 +36,13 @@ public class SettlementResponseForm {
     @Getter
     public static class OrderdMenu {
         private String menu;
+        private Long menuPrice;
         private Integer count;
 
         public static OrderdMenu of(SettlementDto.OrderdMenu orderdMenu) {
             return OrderdMenu.builder()
                     .menu(orderdMenu.getMenu())
+                    .menuPrice(orderdMenu.getMenuPrice())
                     .count(orderdMenu.getCount())
                     .build();
         }

--- a/src/main/java/com/bttf/queosk/dto/UserDetailsResponseForm.java
+++ b/src/main/java/com/bttf/queosk/dto/UserDetailsResponseForm.java
@@ -21,8 +21,6 @@ public class UserDetailsResponseForm {
     private String status;
     private String imageUrl;
     private String loginType;
-    private LocalDateTime createdAt;
-    private LocalDateTime updatedAt;
 
     public static UserDetailsResponseForm of(UserDto userDto) {
         return UserDetailsResponseForm.builder()
@@ -33,8 +31,6 @@ public class UserDetailsResponseForm {
                 .status(userDto.getStatus())
                 .imageUrl(userDto.getImageUrl())
                 .loginType(userDto.getLoginType())
-                .createdAt(userDto.getCreatedAt())
-                .updatedAt(userDto.getUpdatedAt())
                 .build();
     }
 }

--- a/src/main/java/com/bttf/queosk/dto/UserDto.java
+++ b/src/main/java/com/bttf/queosk/dto/UserDto.java
@@ -22,8 +22,6 @@ public class UserDto {
     private String status;
     private String imageUrl;
     private String loginType;
-    private LocalDateTime createdAt;
-    private LocalDateTime updatedAt;
 
     public static UserDto of(User user) {
         return UserDto.builder()
@@ -34,8 +32,6 @@ public class UserDto {
                 .status(user.getStatus().toString())
                 .imageUrl(user.getImageUrl())
                 .loginType(user.getLoginType().toString())
-                .createdAt(user.getCreatedAt())
-                .updatedAt(user.getUpdatedAt())
                 .build();
     }
 }

--- a/src/main/java/com/bttf/queosk/dto/UserEditResponseForm.java
+++ b/src/main/java/com/bttf/queosk/dto/UserEditResponseForm.java
@@ -21,8 +21,6 @@ public class UserEditResponseForm {
     private String status;
     private String imageUrl;
     private String loginType;
-    private LocalDateTime createdAt;
-    private LocalDateTime updatedAt;
 
     public static UserEditResponseForm of(UserDto userDto) {
         return UserEditResponseForm.builder()
@@ -33,8 +31,6 @@ public class UserEditResponseForm {
                 .status(userDto.getStatus())
                 .imageUrl(userDto.getImageUrl())
                 .loginType(userDto.getLoginType())
-                .createdAt(userDto.getCreatedAt())
-                .updatedAt(userDto.getUpdatedAt())
                 .build();
     }
 }

--- a/src/main/java/com/bttf/queosk/service/SettlementService.java
+++ b/src/main/java/com/bttf/queosk/service/SettlementService.java
@@ -1,7 +1,7 @@
 package com.bttf.queosk.service;
 
+import com.bttf.queosk.dto.MenuItemDto;
 import com.bttf.queosk.dto.SettlementDto;
-import com.bttf.queosk.entity.MenuItem;
 import com.bttf.queosk.entity.Order;
 import com.bttf.queosk.entity.Settlement;
 import com.bttf.queosk.repository.MenuItemRepository;
@@ -10,13 +10,11 @@ import com.bttf.queosk.repository.SettlementRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -28,49 +26,49 @@ public class SettlementService {
 
     private final MenuItemRepository menuItemRepository;
 
-    public SettlementDto SettlementGet(Long restaurantId,
-                                       LocalDateTime from,
-                                       LocalDateTime to) {
-
-        Map<String, Integer> menuList = new HashMap<>();
-        Long total = 0L;
-
+    public SettlementDto SettlementGet(Long restaurantId, LocalDateTime from, LocalDateTime to) {
         List<Order> orderByRestaurantInDateRange = orderRepository
                 .findOrderByRestaurantInDateRange(restaurantId, from, to);
 
-        for (Order order : orderByRestaurantInDateRange) {
-            List<MenuItem> allByOrderId = menuItemRepository.findAllByOrderId(order.getId());
-            for (MenuItem menuItem : allByOrderId) {
-                menuList.put(menuItem.getMenu().getName(), menuList.getOrDefault(menuItem.getMenu().getName(), 0) + menuItem.getCount());
-                total += menuItem.getCount() * menuItem.getMenu().getPrice();
-            }
-        }
+        //메뉴 별 가격 반환을 위한 Value 에 MenuItemDto 사용
+        Map<String, MenuItemDto> menuList = orderByRestaurantInDateRange.stream()
+                .flatMap(order -> menuItemRepository.findAllByOrderId(order.getId()).stream())
+                .collect(HashMap::new,
+                        (map, menuItem) -> map.merge(
+                                menuItem.getMenu().getName(),
+                                new MenuItemDto(menuItem.getMenu().getPrice(), menuItem.getCount()),
+                                (existing, replacement) -> existing.addCount(replacement.getCount())
+                        ),
+                        (map1, map2) -> map2.forEach((key, value) -> map1.merge(
+                                key,
+                                value,
+                                (existing, replacement) -> existing.addCount(replacement.getCount())
+                        ))
+                );
 
-        List<SettlementDto.OrderdMenu> orderdMenuList = new ArrayList<>();
-        for (Map.Entry<String, Integer> menu : menuList.entrySet()) {
-            SettlementDto.OrderdMenu orderdMenu = new SettlementDto.OrderdMenu(menu.getKey(), menu.getValue());
-            orderdMenuList.add(orderdMenu);
-        }
+        List<SettlementDto.OrderdMenu> orderdMenuList = menuList.entrySet().stream()
+                .map(entry -> new SettlementDto.OrderdMenu(
+                        entry.getKey(), entry.getValue().getMenuPrice(), entry.getValue().getCount())
+                )
+                .collect(Collectors.toList());
+
+        long total = menuList.values().stream()
+                .mapToLong(menuItemDto -> menuItemDto.getCount() * menuItemDto.getMenuPrice())
+                .sum();
 
         return SettlementDto.of(orderdMenuList, total);
-
     }
 
     public Long periodSettlementPriceGet(Long restaurantId,
-                                         LocalDateTime to,
-                                         LocalDateTime from) {
-        LocalDateTime startDateTime = LocalDateTime.of(LocalDate.from(from), LocalTime.MIN);
-        LocalDateTime endDateTime = LocalDateTime
-                .of(LocalDate.from(to.plusDays(1)), LocalTime.MIN)
-                .minusNanos(1);
-        List<Settlement> settlementList =
-                settlementRepository.findSettlementsByRestaurantInDateRange(restaurantId, startDateTime, endDateTime);
+                                         LocalDateTime from,
+                                         LocalDateTime to) {
 
-        long totalPrice = settlementList.stream()
+        List<Settlement> settlementList =
+                settlementRepository.findSettlementsByRestaurantInDateRange(restaurantId, from, to);
+
+        return settlementList.stream()
                 .mapToLong(Settlement::getPrice)
                 .sum();
-
-        return totalPrice;
     }
 
 }

--- a/src/test/java/com/bttf/queosk/service/OrderServiceTest.java
+++ b/src/test/java/com/bttf/queosk/service/OrderServiceTest.java
@@ -5,16 +5,13 @@ import com.bttf.queosk.entity.*;
 import com.bttf.queosk.enumerate.OperationStatus;
 import com.bttf.queosk.enumerate.OrderStatus;
 import com.bttf.queosk.enumerate.TableStatus;
-import com.bttf.queosk.repository.MenuRepository;
-import com.bttf.queosk.repository.OrderRepository;
-import com.bttf.queosk.repository.RestaurantRepository;
-import com.bttf.queosk.repository.TableRepository;
+import com.bttf.queosk.repository.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.transaction.annotation.Transactional;
+import org.mockito.MockitoAnnotations;
 
 import java.util.Arrays;
 import java.util.List;
@@ -26,10 +23,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-
-@Transactional
-@ExtendWith(MockitoExtension.class)
-class OrderServiceTest {
+@DisplayName("주문 관련 테스트코드")
+public class OrderServiceTest {
 
     @InjectMocks
     private OrderService orderService;
@@ -44,14 +39,21 @@ class OrderServiceTest {
     private RestaurantRepository restaurantRepository;
 
     @Mock
+    private MenuItemRepository menuItemRepository;
+
+    @Mock
     private TableRepository tableRepository;
 
-    @Test
-    public void createOrder_success() {
-        // given
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+    }
 
+    @Test
+    @DisplayName("주문생성 (성공)")
+    public void createOrder_success() {
+        // Given
         Long restaurantId = 1L;
-        String userEmail = "a@x.com";
         Long tableId = 1L;
 
         Restaurant restaurant = Restaurant.builder()
@@ -59,22 +61,20 @@ class OrderServiceTest {
                 .operationStatus(OperationStatus.OPEN)
                 .build();
 
-        Menu menu1 =
-                Menu.builder()
-                        .id(1L)
-                        .name("menu1")
-                        .price(1000L)
-                        .status(ON_SALE)
-                        .restaurantId(restaurantId)
-                        .build();
-        Menu menu2 =
-                Menu.builder()
-                        .id(2L)
-                        .name("menu2")
-                        .price(1000L)
-                        .status(ON_SALE)
-                        .restaurantId(restaurantId)
-                        .build();
+        Menu menu1 = Menu.builder()
+                .id(1L)
+                .name("menu1")
+                .price(1000L)
+                .status(ON_SALE)
+                .restaurantId(restaurantId)
+                .build();
+        Menu menu2 = Menu.builder()
+                .id(2L)
+                .name("menu2")
+                .price(1000L)
+                .status(ON_SALE)
+                .restaurantId(restaurantId)
+                .build();
 
         Table table = Table.builder()
                 .id(1L)
@@ -84,7 +84,7 @@ class OrderServiceTest {
 
         OrderCreationRequestForm.MenuItems menuItem1 = OrderCreationRequestForm.MenuItems.builder()
                 .menu(1L)
-                .count(1)
+                .count(2)
                 .build();
 
         OrderCreationRequestForm.MenuItems menuItem2 = OrderCreationRequestForm.MenuItems.builder()
@@ -105,21 +105,19 @@ class OrderServiceTest {
         given(tableRepository.findById(1L)).willReturn(Optional.of(table));
         given(menuRepository.findById(1L)).willReturn(Optional.of(menu1));
         given(menuRepository.findById(2L)).willReturn(Optional.of(menu2));
-        // when
 
+        // When
         orderService.createOrder(orderCreationForm, 1L);
 
-        // then
-
+        // Then
         verify(orderRepository, times(1)).save(any(Order.class));
     }
 
     @Test
+    @DisplayName("주문상태 변경 (성공)")
     public void updateOrderStatus_success() {
-        // given
-
+        // Given
         Long restaurantId = 1L;
-        Long menuId = 1L;
         Long userId = 1L;
         Long tableId = 1L;
 
@@ -127,14 +125,13 @@ class OrderServiceTest {
                 .id(userId)
                 .build();
 
-        Menu menu1 =
-                Menu.builder()
-                        .id(menuId)
-                        .name("menu1")
-                        .price(1000L)
-                        .status(ON_SALE)
-                        .restaurantId(restaurantId)
-                        .build();
+        Menu menu1 = Menu.builder()
+                .id(1L)
+                .name("menu1")
+                .price(1000L)
+                .status(ON_SALE)
+                .restaurantId(restaurantId)
+                .build();
 
         Table table = Table.builder()
                 .id(tableId)
@@ -153,12 +150,11 @@ class OrderServiceTest {
                 .build();
 
         given(orderRepository.findById(1L)).willReturn(Optional.of(order));
-        // when
 
+        // When
         orderService.updateOrderStatus(1L, 1L, OrderStatus.DONE);
 
-        // then
-
+        // Then
         verify(orderRepository, times(1)).save(any(Order.class));
         assertThat(order.getStatus()).isEqualTo(OrderStatus.DONE);
     }

--- a/src/test/java/com/bttf/queosk/service/UserHistoryTest.java
+++ b/src/test/java/com/bttf/queosk/service/UserHistoryTest.java
@@ -5,6 +5,7 @@ import com.bttf.queosk.entity.Menu;
 import com.bttf.queosk.entity.MenuItem;
 import com.bttf.queosk.entity.Order;
 import com.bttf.queosk.entity.Restaurant;
+import com.bttf.queosk.repository.MenuItemRepository;
 import com.bttf.queosk.repository.OrderRepository;
 import com.bttf.queosk.repository.RestaurantRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -14,10 +15,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 
 import static com.bttf.queosk.enumerate.MenuStatus.ON_SALE;
 import static com.bttf.queosk.enumerate.OrderStatus.DONE;
@@ -33,13 +31,17 @@ public class UserHistoryTest {
 
     @Mock
     private RestaurantRepository restaurantRepository;
+    @Mock
+    private MenuItemRepository menuItemRepositoryRepository;
 
     private UserHistoryService userHistoryService;
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
         userHistoryService =
-                new UserHistoryService(orderRepository, restaurantRepository);
+                new UserHistoryService(
+                        orderRepository, restaurantRepository,menuItemRepositoryRepository
+                );
     }
 
     @Test
@@ -74,10 +76,10 @@ public class UserHistoryTest {
         menus.add(menuItem);
 
         Order order = Order.builder()
+                .id(1L)
                 .userId(userId)
                 .restaurantId(restaurant.getId())
                 .status(DONE)
-                .menuItemList(menus)
                 .build();
 
         List<Order> orders = Collections.singletonList(order);
@@ -86,6 +88,8 @@ public class UserHistoryTest {
                 .thenReturn(orders);
         when(restaurantRepository.findById(restaurant.getId()))
                 .thenReturn(Optional.of(restaurant));
+        when(menuItemRepositoryRepository.findAllByOrderId(1L))
+                .thenReturn(Collections.singletonList(menuItem));
         //when
 
         List<UserHistoryDto> userHistories = userHistoryService.getUserHistories(userId);


### PR DESCRIPTION
### 작업 내용
1. 금일정산, 가격정산 api 응답 비어서 오던 이슈 해결
2. 정산 시 메뉴의 가격 반환하도록 수정
### 변경 사항(추가시엔 추가사항)
1.  `from`/`to` 매개변수의 위치가 뒤바뀌어있었습니다.
`LocalDate` 를 `LocalDateTime`으로 변환하는 `private` 메서드를 두어
중복 코드를 없앴습니다.
변경/추가된 내용을 자세하게 설명
2. `menuItemDto`를 두어 각 메뉴의 가격을 같이 반환하도록 수정했습니다.
### 특이 사항
- 없습니다.