### PR TITLE
Feat: 매장 금일 주문 처리 완료 리스트의 로직 변경

### DIFF
--- a/src/main/java/com/bttf/queosk/repository/OrderRepository.java
+++ b/src/main/java/com/bttf/queosk/repository/OrderRepository.java
@@ -12,6 +12,8 @@ import java.util.List;
 public interface OrderRepository extends JpaRepository<Order, Long> {
     List<Order> findByRestaurantIdAndCreatedAtBetween(Long restaurantId, LocalDateTime startDateTime, LocalDateTime endDateTime);
 
+    List<Order> findByRestaurantIdAndCreatedAtBetweenAndStatus(Long restaurantId, LocalDateTime startDateTime, LocalDateTime endDateTime, OrderStatus orderStatus);
+
     List<Order> findAllByRestaurantIdAndStatus(Long restaurantId, OrderStatus orderStatus);
 
     List<Order> findByUserIdAndStatusNotOrderByCreatedAtDesc(Long userId, OrderStatus orderStatus);

--- a/src/main/java/com/bttf/queosk/service/OrderService.java
+++ b/src/main/java/com/bttf/queosk/service/OrderService.java
@@ -108,8 +108,12 @@ public class OrderService {
     }
 
     public List<OrderDto> readItodayDoneList(Long restaurantId) {
+
+        LocalDateTime startTime = LocalDateTime.now().toLocalDate().atStartOfDay();
+        LocalDateTime endTime = LocalDateTime.now().toLocalDate().atTime(23, 59, 59);
+
         List<Order> orderList =
-                orderRepository.findAllByRestaurantIdAndStatus(restaurantId, DONE);
+                orderRepository.findByRestaurantIdAndCreatedAtBetweenAndStatus(restaurantId, startTime, endTime, DONE);
 
         return orderToOrderDto(orderList);
     }


### PR DESCRIPTION
### 작업 내용
금일 처리 완료한 주문만 표시되도록 변경하였습니다

### 변경 사항(추가시엔 추가사항)
이전엔 전날 처리한 주문도 금일 처리 주문 리스트에 포함되었었습니다.
금일 처리 완료한 주문만 표시되도록 변경하였습니다.

### 특이 사항
없습니다.

### 관련 이슈(옵셔널)
없습니다.