### PR TITLE
Refactor: 이미지 수정 시 기존 이미지 S3 bucket 에서 삭제하도록 수정

### DIFF
--- a/src/main/java/com/bttf/queosk/controller/MenuController.java
+++ b/src/main/java/com/bttf/queosk/controller/MenuController.java
@@ -15,7 +15,6 @@ import org.springframework.web.multipart.MultipartFile;
 import javax.validation.Valid;
 import java.io.IOException;
 import java.util.List;
-import java.util.UUID;
 
 import static org.springframework.http.HttpStatus.*;
 
@@ -47,7 +46,7 @@ public class MenuController {
     public ResponseEntity<MenuListResponseForm> getMenu(
             @PathVariable("restaurantId") Long restaurantId) {
 
-        List<MenuDto> menuList = menuService.getMenu(restaurantId);
+        List<MenuDto> menuList = menuService.getMenus(restaurantId);
 
         return ResponseEntity.status(OK).body(MenuListResponseForm.of(menuList));
     }
@@ -105,6 +104,10 @@ public class MenuController {
 
         String url =
                 imageService.saveFile(imageFile, "/restaurant/" + restaurantId + "/menu");
+
+        MenuDto menuDto = menuService.getMenu(menuId);
+
+        imageService.deleteFile(menuDto.getImageUrl());
 
         menuService.updateImage(restaurantId, menuId, url);
 

--- a/src/main/java/com/bttf/queosk/controller/UserController.java
+++ b/src/main/java/com/bttf/queosk/controller/UserController.java
@@ -154,9 +154,13 @@ public class UserController {
 
         Long userId = jwtTokenProvider.getIdFromToken(token);
 
-        String url = imageService.saveFile(image, "user");
+        UserDto userDto = userInfoService.getUserDetails(userId);
 
-        userInfoService.updateImageUrl(userId, url);
+        // 기존 이미지 삭제
+        imageService.deleteFile(userDto.getImageUrl());
+
+        // 새로운 이미지경로 업데이트
+        userInfoService.updateImageUrl(userId, imageService.saveFile(image, "user"));
 
         return ResponseEntity.status(NO_CONTENT).build();
     }

--- a/src/main/java/com/bttf/queosk/service/AutoCompleteService.java
+++ b/src/main/java/com/bttf/queosk/service/AutoCompleteService.java
@@ -6,6 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -25,15 +26,18 @@ public class AutoCompleteService {
             "ㅅ", "ㅆ", "ㅇ", "ㅈ", "ㅉ", "ㅊ", "ㅋ", "ㅌ", "ㅍ", "ㅎ"};
 
     //검색어 등록
+    @Transactional
     public void addAutoCompleteWord(String restaurant) {
         redisTemplate.opsForZSet().add(AUTOCOMPLETE_KEY, restaurant, 0);
     }
 
     //등록된 검색어 삭제
+    @Transactional
     public void deleteAutoCompleteWord(String restaurant) {
         redisTemplate.opsForZSet().remove(AUTOCOMPLETE_KEY, restaurant);
     }
 
+    @Transactional(readOnly = true)
     public AutoCompleteDto autoComplete(String input) {
 
         List<String> matchingKeywords = new ArrayList<>(

--- a/src/main/java/com/bttf/queosk/service/KakaoLoginService.java
+++ b/src/main/java/com/bttf/queosk/service/KakaoLoginService.java
@@ -18,6 +18,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.*;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.HttpClientErrorException;
@@ -49,6 +50,7 @@ public class KakaoLoginService {
     @Value("${kakao.redirectUrl}")
     private String KAKAO_REDIRECT_URL;
 
+    @Transactional
     public void logoutKakaoUser(String email) {
         KakaoAuth kakaoAuth = kakaoAuthRepository.findById(email);
 
@@ -58,6 +60,7 @@ public class KakaoLoginService {
         }
     }
 
+    @Transactional
     public UserSignInDto getUserInfoFromKakao(KakaoLoginRequestForm kaKaoLoginRequestForm) throws CustomException {
         String accessToken = "";
         String refreshToken = "";
@@ -101,6 +104,7 @@ public class KakaoLoginService {
     }
 
     //임시 서비스
+    @Transactional
     public UserSignInDto getUserInfoFromKakaoTest(KakaoLoginRequestForm kaKaoLoginRequestForm) throws CustomException {
         String accessToken = "";
         String refreshToken = "";

--- a/src/main/java/com/bttf/queosk/service/MenuService.java
+++ b/src/main/java/com/bttf/queosk/service/MenuService.java
@@ -31,7 +31,7 @@ public class MenuService {
 
     @Transactional(readOnly = true)
     @Cacheable(value = "menuList", key = "'restaurantId:' + #restaurantId")
-    public List<MenuDto> getMenu(Long restaurantId) {
+    public List<MenuDto> getMenus(Long restaurantId) {
 
         List<Menu> menus = menuRepository.findByRestaurantId(restaurantId);
 
@@ -93,5 +93,12 @@ public class MenuService {
                 .orElseThrow(() -> new CustomException(MENU_NOT_FOUND));
 
         menuRepository.delete(menu);
+    }
+
+    @Transactional(readOnly = true)
+    public MenuDto getMenu(Long menuId) {
+        Menu menu =  menuRepository.findById(menuId).orElseThrow(()->
+                new CustomException(MENU_NOT_FOUND));
+        return MenuDto.of(menu);
     }
 }

--- a/src/main/java/com/bttf/queosk/service/QueueService.java
+++ b/src/main/java/com/bttf/queosk/service/QueueService.java
@@ -160,6 +160,7 @@ public class QueueService {
         });
     }
 
+    @Transactional(readOnly = true)
     public List<QueueOfUserDto> getUserQueueList(Long userId) {
         List<Queue> userQueues = queueRepository.findByUserId(userId);
 

--- a/src/main/java/com/bttf/queosk/service/RefreshTokenService.java
+++ b/src/main/java/com/bttf/queosk/service/RefreshTokenService.java
@@ -13,6 +13,7 @@ import com.bttf.queosk.repository.RestaurantRepository;
 import com.bttf.queosk.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import static com.bttf.queosk.enumerate.UserRole.ROLE_USER;
 import static com.bttf.queosk.exception.ErrorCode.*;
@@ -26,6 +27,7 @@ public class RefreshTokenService {
     private final JwtTokenProvider jwtTokenProvider;
 
     // 신규 AccessToken 발급
+    @Transactional
     public TokenRefreshDto issueNewAccessToken(String accessToken, String refreshToken) {
         validateRefreshToken(refreshToken);
 
@@ -62,6 +64,7 @@ public class RefreshTokenService {
     }
 
     // 리프레시 토큰 삭제
+    @Transactional
     public void deleteRefreshToken(String email) {
         refreshTokenRepository.deleteByEmail(email);
     }

--- a/src/main/java/com/bttf/queosk/service/UserHistoryService.java
+++ b/src/main/java/com/bttf/queosk/service/UserHistoryService.java
@@ -10,6 +10,7 @@ import com.bttf.queosk.repository.OrderRepository;
 import com.bttf.queosk.repository.RestaurantRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -20,6 +21,8 @@ public class UserHistoryService {
     private final OrderRepository orderRepository;
     private final RestaurantRepository restaurantRepository;
     private final MenuItemRepository menuItemRepository;
+
+    @Transactional(readOnly = true)
     public List<UserHistoryDto> getUserHistories(Long userId) {
         List<Order> orders = orderRepository.findByUserIdAndStatusNotOrderByCreatedAtDesc(
                 userId, OrderStatus.IN_PROGRESS

--- a/src/main/resources/templates/verification-result.html
+++ b/src/main/resources/templates/verification-result.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta content="width=device-width, initial-scale=1.0" name="viewport">
-    <title>회원가입 완료(임시화면)</title>
+    <title>회원가입 완료</title>
     <style>
         body {
             font-family: Arial, sans-serif;
@@ -13,29 +13,34 @@
             justify-content: center;
             height: 100vh;
             margin: 0;
+            padding: 0 30px;
         }
 
         .message {
-            font-size: 24px;
+            font-size: 18px;
             text-align: center;
-            margin-bottom: 20px;
+            margin: -18px 0 20px;
+        }
+        .message p {
+            margin: 18px 0;
         }
 
         .button {
-            background-color: #007bff;
+            background-color: #ff8901;
             color: white;
             padding: 10px 20px;
             border: none;
-            border-radius: 5px;
+            border-radius: 8px;
             cursor: pointer;
-            font-size: 18px;
+            font-size: 16px;
+            text-decoration: none;
         }
     </style>
 </head>
 <body>
 <div class="message">
     <p th:text="${message}"></p>
-    <p>아래 버튼을 눌러 앱에서 로그인을 진행해주세요.</p>
+    <p>아래 버튼을 누른 후 <br>앱에서 로그인을 진행해주세요.</p>
 </div>
 <a class="button" href="https://queosk.kr/">앱으로 돌아가기</a>
 </body>

--- a/src/main/resources/templates/verification-result.html
+++ b/src/main/resources/templates/verification-result.html
@@ -37,6 +37,6 @@
     <p th:text="${message}"></p>
     <p>아래 버튼을 눌러 앱에서 로그인을 진행해주세요.</p>
 </div>
-<a class="button" href="http://localhost:8080/">앱으로 돌아가기</a>
+<a class="button" href="https://queosk.kr/">앱으로 돌아가기</a>
 </body>
 </html>

--- a/src/test/java/com/bttf/queosk/service/MenuServiceTest.java
+++ b/src/test/java/com/bttf/queosk/service/MenuServiceTest.java
@@ -82,7 +82,7 @@ class MenuServiceTest {
         when(menuRepository.findByRestaurantId(restaurantId)).thenReturn(menus);
 
         // When
-        List<MenuDto> menuDtos = menuService.getMenu(restaurantId);
+        List<MenuDto> menuDtos = menuService.getMenus(restaurantId);
 
         // Then
         assertThat(menuDtos.size()).isEqualTo(2);
@@ -100,7 +100,7 @@ class MenuServiceTest {
         when(menuRepository.findByRestaurantId(restaurantId)).thenReturn(new ArrayList<>());
 
         // When & Then
-        assertThatThrownBy(() -> menuService.getMenu(restaurantId))
+        assertThatThrownBy(() -> menuService.getMenus(restaurantId))
                 .isInstanceOf(CustomException.class);
     }
 


### PR DESCRIPTION
### 작업 내용
- 이미지 수정 시 기존 이미지 S3 bucket 에서 삭제하도록 수정
- 누락된`@Transactional` 어노테이션 추가
- 이메일 인증완료 화면 UI 및 기능 수정 
### 변경 사항(추가시엔 추가사항)
- 메뉴/고객 관리 api중 이미지 업데이트 api 호출 시 기존 image경로를 S3 bucket에서 삭제하도록 코드를 수정했습니다.
- 서비스레이어에 `@Transaction`이 누락된 메서드들에 대해 해당 어노테이션을 추가했습니다.
- 이메일 인증완료 화면 내 버튼 색상을 앱 화면 내 버튼 색상과 맞추고, 버튼 내 href 경로를 실제 앱 경로("https://queosk.kr") 로 수정했습니다.
### 특이 사항
- 없습니다.
