### PR TITLE
Feat: updateTable 메소드를 테이블 상태, 이름을 바꿀 수 있도록 수정

### DIFF
--- a/src/main/java/com/bttf/queosk/controller/TableController.java
+++ b/src/main/java/com/bttf/queosk/controller/TableController.java
@@ -4,6 +4,7 @@ import com.bttf.queosk.config.JwtTokenProvider;
 import com.bttf.queosk.dto.TableDto;
 import com.bttf.queosk.dto.TableRequestForm;
 import com.bttf.queosk.dto.TableResponseForm;
+import com.bttf.queosk.dto.TableUpdateForm;
 import com.bttf.queosk.enumerate.TableStatus;
 import com.bttf.queosk.service.QueueService;
 import com.bttf.queosk.service.TableService;
@@ -40,19 +41,19 @@ public class TableController {
         return ResponseEntity.status(CREATED).build();
     }
     @PutMapping("/table/{tableId}")
-    @ApiOperation(value = "매장 테이블 상태 변경", notes = "매장 테이블의 상태를 변경 합니다.")
+    @ApiOperation(value = "매장 테이블 수정", notes = "매장 테이블의 상태와 이름을 변경 합니다.")
     public ResponseEntity<Void> tableUpdate(@RequestHeader(HttpHeaders.AUTHORIZATION) String token,
-                                            @RequestParam TableStatus tableStatus,
+                                            @RequestBody TableUpdateForm form,
                                             @PathVariable Long tableId) {
 
 
         Long restaurantId = jwtTokenProvider.getIdFromToken(token);
 
-        if (tableStatus.equals(OPEN)) {
+        if (form.getTableStatus().equals(OPEN)) {
             queueService.popTheFirstTeamOfQueue(restaurantId);
         }
 
-        tableService.updateTable(tableId, tableStatus, restaurantId);
+        tableService.updateTable(tableId, form, restaurantId);
         return ResponseEntity.status(NO_CONTENT).build();
     }
 

--- a/src/main/java/com/bttf/queosk/dto/TableUpdateForm.java
+++ b/src/main/java/com/bttf/queosk/dto/TableUpdateForm.java
@@ -1,0 +1,14 @@
+package com.bttf.queosk.dto;
+
+import com.bttf.queosk.enumerate.TableStatus;
+import io.swagger.annotations.ApiModel;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@ApiModel(value = "테이블 업데이트 Request")
+public class TableUpdateForm {
+    TableStatus tableStatus;
+    String name;
+}

--- a/src/main/java/com/bttf/queosk/entity/Table.java
+++ b/src/main/java/com/bttf/queosk/entity/Table.java
@@ -38,7 +38,8 @@ public class Table extends BaseTimeEntity {
                 .build();
     }
 
-    public void setStatus(TableStatus status) {
+    public void setStatusAndName(TableStatus status, String name) {
         this.status = status;
+        this.name = name;
     }
 }

--- a/src/main/java/com/bttf/queosk/service/OrderService.java
+++ b/src/main/java/com/bttf/queosk/service/OrderService.java
@@ -55,7 +55,7 @@ public class OrderService {
                 .build()).collect(Collectors.toList());
 
         validOrder(restaurant, table, menuItemList);
-        table.setStatus(USING);
+        table.setStatusAndName(USING, table.getName());
         orderRepository.save(order);
         menuItemRepository.saveAll(menuItemList);
     }

--- a/src/main/java/com/bttf/queosk/service/TableService.java
+++ b/src/main/java/com/bttf/queosk/service/TableService.java
@@ -3,6 +3,7 @@ package com.bttf.queosk.service;
 
 import com.bttf.queosk.dto.TableDto;
 import com.bttf.queosk.dto.TableRequestForm;
+import com.bttf.queosk.dto.TableUpdateForm;
 import com.bttf.queosk.entity.Table;
 import com.bttf.queosk.enumerate.TableStatus;
 import com.bttf.queosk.exception.CustomException;
@@ -34,7 +35,7 @@ public class TableService {
 
     @Transactional
     @CacheEvict(value = "tableList", key = "'restaurantId:' + #restaurantId")
-    public void updateTable(Long tableId, TableStatus tableStatus, Long restaurantId) {
+    public void updateTable(Long tableId, TableUpdateForm form, Long restaurantId) {
 
         Table table = getTableFromRepository(tableId);
 
@@ -42,7 +43,7 @@ public class TableService {
             throw new CustomException(NOT_PERMITTED);
         }
 
-        table.setStatus(tableStatus);
+        table.setStatusAndName(form.getTableStatus(), form.getName());
     }
 
     @Transactional

--- a/src/test/java/com/bttf/queosk/service/TableServiceTest.java
+++ b/src/test/java/com/bttf/queosk/service/TableServiceTest.java
@@ -2,6 +2,7 @@ package com.bttf.queosk.service;
 
 import com.bttf.queosk.dto.TableDto;
 import com.bttf.queosk.dto.TableRequestForm;
+import com.bttf.queosk.dto.TableUpdateForm;
 import com.bttf.queosk.entity.Restaurant;
 import com.bttf.queosk.entity.Table;
 import com.bttf.queosk.enumerate.TableStatus;
@@ -73,13 +74,19 @@ class TableServiceTest {
                 .restaurantId(1L)
                 .build();
 
+        TableUpdateForm form = TableUpdateForm.builder()
+                .tableStatus(TableStatus.USING)
+                .name("name")
+                .build();
+
         given(tableRepository.findById(table.getId())).willReturn(Optional.of(table));
 
         //when
-        tableService.updateTable(table.getId(), TableStatus.USING, restaurantId);
+        tableService.updateTable(table.getId(), form, restaurantId);
 
         //then
-        then(tableService).should(times(1)).updateTable(table.getId(), TableStatus.USING, restaurantId);
+        then(tableService).should(times(1)).updateTable(table.getId(), form, restaurantId);
+        assertThat(table.getName()).isEqualTo("name");
     }
 
     @Test
@@ -92,13 +99,18 @@ class TableServiceTest {
                 .restaurantId(1L)
                 .build();
 
+        TableUpdateForm form = TableUpdateForm.builder()
+                .tableStatus(TableStatus.USING)
+                .name("name")
+                .build();
+
         given(tableRepository.findById(anyLong())).willReturn(Optional.empty());
 
         //then
-        assertThatThrownBy(() -> tableService.updateTable(table.getId(), TableStatus.USING, table.getRestaurantId()))
+        assertThatThrownBy(() -> tableService.updateTable(table.getId(), form, table.getRestaurantId()))
                 .isExactlyInstanceOf(CustomException.class)
                 .hasMessage(ErrorCode.INVALID_TABLE.getMessage());
-        then(tableService).should(times(1)).updateTable(table.getId(), TableStatus.USING, table.getRestaurantId());
+        then(tableService).should(times(1)).updateTable(table.getId(), form, table.getRestaurantId());
     }
 
     @Test
@@ -111,13 +123,18 @@ class TableServiceTest {
                 .restaurantId(1L)
                 .build();
 
+        TableUpdateForm form = TableUpdateForm.builder()
+                .tableStatus(TableStatus.USING)
+                .name("name")
+                .build();
+
         given(tableRepository.findById(table.getId())).willReturn(Optional.of(table));
 
         //then
-        assertThatThrownBy(() -> tableService.updateTable(table.getId(), TableStatus.USING, 2L))
+        assertThatThrownBy(() -> tableService.updateTable(table.getId(), form, 2L))
                 .isExactlyInstanceOf(CustomException.class)
                 .hasMessage(ErrorCode.NOT_PERMITTED.getMessage());
-        then(tableService).should(times(1)).updateTable(table.getId(), TableStatus.USING, 2L);
+        then(tableService).should(times(1)).updateTable(table.getId(), form, 2L);
     }
 
     @Test


### PR DESCRIPTION
### 작업 내용
- updateTable 메소드에서 테이블 상태만 받아 수정할 수 있던 것을, 이름 또한 받아 바꿀 수 있도록 수정

### 변경 사항(추가시엔 추가사항)
- TableService 코드 수정
- TableController 코드 수정
- TableUpdateForm 생성
- 관련 테스트 코드 수정 후 테스트 및 API 테스트

### 특이 사항
없음

### 관련 이슈(옵셔널)
없음