### PR TITLE
Feat: updateTable 메소드 분리 및 수정

### DIFF
--- a/src/main/java/com/bttf/queosk/controller/TableController.java
+++ b/src/main/java/com/bttf/queosk/controller/TableController.java
@@ -2,6 +2,7 @@ package com.bttf.queosk.controller;
 
 import com.bttf.queosk.config.JwtTokenProvider;
 import com.bttf.queosk.dto.TableDto;
+import com.bttf.queosk.dto.TableNameUpdateForm;
 import com.bttf.queosk.dto.TableRequestForm;
 import com.bttf.queosk.dto.TableResponseForm;
 import com.bttf.queosk.enumerate.TableStatus;
@@ -39,9 +40,9 @@ public class TableController {
         tableService.createTable(restaurantId, form);
         return ResponseEntity.status(CREATED).build();
     }
-    @PutMapping("/table/{tableId}")
+    @PutMapping("/table/{tableId}/status")
     @ApiOperation(value = "매장 테이블 상태 변경", notes = "매장 테이블의 상태를 변경 합니다.")
-    public ResponseEntity<Void> tableUpdate(@RequestHeader(HttpHeaders.AUTHORIZATION) String token,
+    public ResponseEntity<Void> tableStatusUpdate(@RequestHeader(HttpHeaders.AUTHORIZATION) String token,
                                             @RequestParam TableStatus tableStatus,
                                             @PathVariable Long tableId) {
 
@@ -52,7 +53,17 @@ public class TableController {
             queueService.popTheFirstTeamOfQueue(restaurantId);
         }
 
-        tableService.updateTable(tableId, tableStatus, restaurantId);
+        tableService.updateTableStatus(tableId, tableStatus, restaurantId);
+        return ResponseEntity.status(NO_CONTENT).build();
+    }
+
+    @PatchMapping("/table/{tableId}/name")
+    @ApiOperation(value = "매장 테이블 이름 변경", notes = "매장 테이블의 이름을 변경 합니다.")
+    public ResponseEntity<Void> tableNameUpdate(@RequestHeader(HttpHeaders.AUTHORIZATION) String token,
+                                                @RequestBody TableNameUpdateForm tableNameUpdateForm,
+                                                @PathVariable Long tableId) {
+        Long restaurantId = jwtTokenProvider.getIdFromToken(token);
+        tableService.updateTableName(tableId, tableNameUpdateForm, restaurantId);
         return ResponseEntity.status(NO_CONTENT).build();
     }
 

--- a/src/main/java/com/bttf/queosk/dto/TableNameUpdateForm.java
+++ b/src/main/java/com/bttf/queosk/dto/TableNameUpdateForm.java
@@ -1,0 +1,16 @@
+package com.bttf.queosk.dto;
+
+import io.swagger.annotations.ApiModel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@ApiModel(value = "테이블 이름 변경 Response")
+public class TableNameUpdateForm {
+    String name;
+}

--- a/src/main/java/com/bttf/queosk/entity/Table.java
+++ b/src/main/java/com/bttf/queosk/entity/Table.java
@@ -41,4 +41,6 @@ public class Table extends BaseTimeEntity {
     public void setStatus(TableStatus status) {
         this.status = status;
     }
+
+    public void setName(String name) { this.name = name; }
 }

--- a/src/main/java/com/bttf/queosk/service/TableService.java
+++ b/src/main/java/com/bttf/queosk/service/TableService.java
@@ -2,6 +2,7 @@ package com.bttf.queosk.service;
 
 
 import com.bttf.queosk.dto.TableDto;
+import com.bttf.queosk.dto.TableNameUpdateForm;
 import com.bttf.queosk.dto.TableRequestForm;
 import com.bttf.queosk.entity.Table;
 import com.bttf.queosk.enumerate.TableStatus;
@@ -34,26 +35,27 @@ public class TableService {
 
     @Transactional
     @CacheEvict(value = "tableList", key = "'restaurantId:' + #restaurantId")
-    public void updateTable(Long tableId, TableStatus tableStatus, Long restaurantId) {
+    public void updateTableStatus(Long tableId, TableStatus tableStatus, Long restaurantId) {
 
-        Table table = getTableFromRepository(tableId);
-
-        if (!restaurantId.equals(table.getRestaurantId())) {
-            throw new CustomException(NOT_PERMITTED);
-        }
+        Table table = getTableAndValid(tableId, restaurantId);
 
         table.setStatus(tableStatus);
     }
 
     @Transactional
     @CacheEvict(value = "tableList", key = "'restaurantId:' + #restaurantId")
+    public void updateTableName(Long tableId, TableNameUpdateForm tableNameUpdateForm,
+                                Long restaurantId) {
+        Table table = getTableAndValid(tableId, restaurantId);
+
+        table.setName(tableNameUpdateForm.getName());
+    }
+
+    @Transactional
+    @CacheEvict(value = "tableList", key = "'restaurantId:' + #restaurantId")
     public void deleteTable(Long tableId, Long restaurantId) {
 
-        Table table = getTableFromRepository(tableId);
-
-        if (!restaurantId.equals(table.getRestaurantId())) {
-            throw new CustomException(NOT_PERMITTED);
-        }
+        Table table = getTableAndValid(tableId, restaurantId);
 
         tableRepository.delete(table);
     }
@@ -61,11 +63,7 @@ public class TableService {
     @Transactional(readOnly = true)
     public TableDto getTable(Long tableId, Long restaurantId) {
 
-        Table table = getTableFromRepository(tableId);
-
-        if (!restaurantId.equals(table.getRestaurantId())) {
-            throw new CustomException(NOT_PERMITTED);
-        }
+        Table table = getTableAndValid(tableId, restaurantId);
 
         return TableDto.of(table);
     }
@@ -88,11 +86,26 @@ public class TableService {
                 .collect(Collectors.toList());
     }
 
+    private Table getTableAndValid(Long tableId, Long restaurantId) {
+        Table table = getTableFromRepository(tableId);
+
+        tableRestaurantValid(restaurantId, table);
+
+        return table;
+    }
+
+    private static void tableRestaurantValid(Long restaurantId, Table table) {
+        if (!restaurantId.equals(table.getRestaurantId())) {
+            throw new CustomException(NOT_PERMITTED);
+        }
+    }
+
     private Table getTableFromRepository(Long tableId) {
         return tableRepository.findById(tableId).orElseThrow(
                 () -> new CustomException(INVALID_TABLE)
         );
     }
+
 
 
 }

--- a/src/test/java/com/bttf/queosk/service/TableServiceTest.java
+++ b/src/test/java/com/bttf/queosk/service/TableServiceTest.java
@@ -1,6 +1,7 @@
 package com.bttf.queosk.service;
 
 import com.bttf.queosk.dto.TableDto;
+import com.bttf.queosk.dto.TableNameUpdateForm;
 import com.bttf.queosk.dto.TableRequestForm;
 import com.bttf.queosk.entity.Restaurant;
 import com.bttf.queosk.entity.Table;
@@ -63,7 +64,7 @@ class TableServiceTest {
     }
 
     @Test
-    @DisplayName("테이블 수정 (성공)")
+    @DisplayName("테이블 상태 수정 (성공)")
     public void testUpdateTable_success() {
         Long restaurantId = 1L;
         //given
@@ -83,7 +84,7 @@ class TableServiceTest {
     }
 
     @Test
-    @DisplayName("테이블 수정 (실패-table 찾을 수 없을 경우)")
+    @DisplayName("테이블 상태 수정 (실패-table 찾을 수 없을 경우)")
     public void testUpdateTable_fail_invalidTableException() {
         //given
         Table table = Table.builder()
@@ -102,7 +103,7 @@ class TableServiceTest {
     }
 
     @Test
-    @DisplayName("테이블 수정 (실패-본인 restaurant 의 table 이 아닌 경우)")
+    @DisplayName("테이블 상태 수정 (실패-본인 restaurant 의 table 이 아닌 경우)")
     public void testUpdateTable_fail_NotPermittedTableException() {
         //given
         Table table = Table.builder()
@@ -118,6 +119,76 @@ class TableServiceTest {
                 .isExactlyInstanceOf(CustomException.class)
                 .hasMessage(ErrorCode.NOT_PERMITTED.getMessage());
         then(tableService).should(times(1)).updateTable(table.getId(), TableStatus.USING, 2L);
+    }
+
+    @Test
+    @DisplayName("테이블 이름 수정 (성공)")
+    public void testTableNameUpdate_success() {
+        Long restaurantId = 1L;
+        //given
+        Table table = Table.builder()
+                .id(1L)
+                .status(TableStatus.OPEN)
+                .restaurantId(1L)
+                .build();
+
+        TableNameUpdateForm form = TableNameUpdateForm.builder()
+                .name("test")
+                .build();
+
+        given(tableRepository.findById(table.getId())).willReturn(Optional.of(table));
+
+        //when
+        tableService.updateTableName(table.getId(), form, restaurantId);
+
+        //then
+        then(tableService).should(times(1)).updateTableName(table.getId(), form, restaurantId);
+    }
+
+    @Test
+    @DisplayName("테이블 이름 수정 (실패-table 찾을 수 없을 경우)")
+    public void testUpdateTableName_fail_invalidTableException() {
+        //given
+        Table table = Table.builder()
+                .id(1L)
+                .status(TableStatus.OPEN)
+                .restaurantId(1L)
+                .build();
+
+        TableNameUpdateForm form = TableNameUpdateForm.builder()
+                .name("test")
+                .build();
+
+        given(tableRepository.findById(anyLong())).willReturn(Optional.empty());
+
+        //then
+        assertThatThrownBy(() -> tableService.updateTableName(table.getId(), form, table.getRestaurantId()))
+                .isExactlyInstanceOf(CustomException.class)
+                .hasMessage(ErrorCode.INVALID_TABLE.getMessage());
+        then(tableService).should(times(1)).updateTableName(table.getId(), form, table.getRestaurantId());
+    }
+
+    @Test
+    @DisplayName("테이블 이름 수정 (실패-본인 restaurant 의 table 이 아닌 경우)")
+    public void testUpdateTableName_fail_NotPermittedTableException() {
+        //given
+        Table table = Table.builder()
+                .id(1L)
+                .status(TableStatus.OPEN)
+                .restaurantId(1L)
+                .build();
+
+        TableNameUpdateForm form = TableNameUpdateForm.builder()
+                .name("test")
+                .build();
+
+        given(tableRepository.findById(table.getId())).willReturn(Optional.of(table));
+
+        //then
+        assertThatThrownBy(() -> tableService.updateTableName(table.getId(), form, 2L))
+                .isExactlyInstanceOf(CustomException.class)
+                .hasMessage(ErrorCode.NOT_PERMITTED.getMessage());
+        then(tableService).should(times(1)).updateTableName(table.getId(), form, 2L);
     }
 
     @Test


### PR DESCRIPTION
### 작업 내용

updateTable 메소드를 updateTableStatus와 updateTableName으로 분리 및 코드 리팩토링.

### 변경 사항(추가시엔 추가사항)

- TableService 코드 수정 및 리팩토링.
- TableController 코드 수정
- TableUpdateForm 생성
- 관련 테스트 코드 수정 후 테스트
- API 테스트

### 특이 사항
PR을 리뷰하면서 주의해야 할 사항이나 특이한 부분

### 관련 이슈(옵셔널)
이 PR과 관련된 이슈 번호