### PR TITLE
Refactor: 리뷰/웨이팅 등록 시 동시성 제어

### DIFF
--- a/src/main/java/com/bttf/queosk/config/AsyncConfig.java
+++ b/src/main/java/com/bttf/queosk/config/AsyncConfig.java
@@ -1,0 +1,30 @@
+package com.bttf.queosk.config;
+
+import com.bttf.queosk.exception.AsyncUncaughtExceptionHandlerCustom;
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurerSupport;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@EnableAsync
+@Configuration
+public class AsyncConfig extends AsyncConfigurerSupport {
+
+    public Executor getAsyncExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2); // 디폴트로 실행 대기 중인 Thread 수
+        executor.setMaxPoolSize(10); // 동시에 동작하는 최대 Thread 수
+        executor.setQueueCapacity(20); // CorePool이 초과될때 Queue에 저장했다가 꺼내서 실행. (20개까지 저장)
+        executor.setThreadNamePrefix("async-"); // Spring에서 생성하는 Thread 접두사
+        executor.initialize();
+        return executor;
+    }
+
+    public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
+        return new AsyncUncaughtExceptionHandlerCustom();
+    }
+
+}

--- a/src/main/java/com/bttf/queosk/entity/Restaurant.java
+++ b/src/main/java/com/bttf/queosk/entity/Restaurant.java
@@ -6,10 +6,7 @@ import com.bttf.queosk.entity.baseentity.BaseTimeEntity;
 import com.bttf.queosk.enumerate.OperationStatus;
 import com.bttf.queosk.enumerate.RestaurantCategory;
 import com.bttf.queosk.enumerate.UserRole;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.hibernate.envers.AuditOverride;
 
 import javax.persistence.*;
@@ -58,6 +55,7 @@ public class Restaurant extends BaseTimeEntity {
 
     private String region;
 
+    @Setter
     private Double ratingAverage;
 
     private String imageUrl;
@@ -105,4 +103,5 @@ public class Restaurant extends BaseTimeEntity {
     public void setRegion(String region) {
         this.region = region;
     }
+
 }

--- a/src/main/java/com/bttf/queosk/enumerate/EmailComponents.java
+++ b/src/main/java/com/bttf/queosk/enumerate/EmailComponents.java
@@ -1,0 +1,13 @@
+package com.bttf.queosk.enumerate;
+
+public class EmailComponents {
+    public final static String VERIFICATION_SUBJECT = "Queosk 이메일 인증";
+    public final static String VERIFICATION_TEXT =
+            "Queosk에 가입해 주셔서 감사합니다.\n" +
+                    "아래 링크를 클릭 하시어 이메일 인증을 완료해주세요.\n" +
+                    "https://queosk.kr/api/users/%d/verification";
+
+    public final static String PASSWORD_RESET_SUBJECT = "Queosk 비밀번호 재설정";
+    public final static String PASSWORD_RESET_TEXT =
+            "새로운 비밀번호 : %s를 입력해 로그인 해주세요.";
+}

--- a/src/main/java/com/bttf/queosk/exception/AsyncUncaughtExceptionHandlerCustom.java
+++ b/src/main/java/com/bttf/queosk/exception/AsyncUncaughtExceptionHandlerCustom.java
@@ -1,0 +1,18 @@
+package com.bttf.queosk.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+
+@Slf4j
+public class AsyncUncaughtExceptionHandlerCustom implements AsyncUncaughtExceptionHandler {
+    @Override
+    public void handleUncaughtException(Throwable ex, Method method, Object... params) {
+        log.error("Async Exception - " + ex.getMessage());
+        log.error("Async Method - " + method.getName());
+        Arrays.stream(params).forEach(param -> log.error("Parameter value - " + param));
+        throw new RuntimeException(ex.getMessage());
+    }
+}

--- a/src/main/java/com/bttf/queosk/exception/ErrorCode.java
+++ b/src/main/java/com/bttf/queosk/exception/ErrorCode.java
@@ -73,8 +73,8 @@ public enum ErrorCode {
     UNDEFINED_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "정의되지 않은 예외가 발생했습니다. 메세지를 참고해주세요."),
 
     // 리프레시 토큰 Exception
-    REFRESH_CODE_EXPIRED(HttpStatus.UNAUTHORIZED, "리프레시토큰이 만료되었습니다. 재로그인이 필요합니다.");
-
+    REFRESH_CODE_EXPIRED(HttpStatus.UNAUTHORIZED, "리프레시토큰이 만료되었습니다. 재로그인이 필요합니다."),
+    RETRY_TO_CREATE_QUEUE(HttpStatus.INTERNAL_SERVER_ERROR, "웨이팅 생성에 실패했습니다. 다시 시도해주세요");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/bttf/queosk/repository/QueueRedisRepository.java
+++ b/src/main/java/com/bttf/queosk/repository/QueueRedisRepository.java
@@ -12,9 +12,10 @@ import java.util.concurrent.TimeUnit;
 public class QueueRedisRepository {
     private final RedisTemplate<String, String> redisTemplate;
 
-    public void createQueue(String restaurantId, String queueId) {
+    public String createQueue(String restaurantId, String queueId) {
         redisTemplate.opsForList().rightPush(restaurantId, queueId);
         redisTemplate.expire(restaurantId, 24, TimeUnit.HOURS);
+        return queueId;
     }
 
     public List<String> findAll(String restaurantId) {
@@ -31,5 +32,17 @@ public class QueueRedisRepository {
 
     public void deleteQueue(String restaurantId, String queueId) {
         redisTemplate.opsForList().remove(restaurantId, 0, queueId);
+    }
+
+    public boolean setIfNotExists(String key, String value) {
+        return Boolean.TRUE.equals(redisTemplate.opsForValue().setIfAbsent(key, value));
+    }
+
+    public void deleteLockKey(String key) {
+        redisTemplate.delete(key);
+    }
+
+    public void expire(String key, int expireSeconds) {
+        redisTemplate.expire(key, expireSeconds, TimeUnit.SECONDS);
     }
 }

--- a/src/main/java/com/bttf/queosk/service/EmailSender.java
+++ b/src/main/java/com/bttf/queosk/service/EmailSender.java
@@ -1,16 +1,20 @@
 package com.bttf.queosk.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.mail.MailException;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @RequiredArgsConstructor
 @Component
 public class EmailSender {
     private final JavaMailSender javaMailSender;
 
+    @Async
     public void sendEmail(String to, String subject, String text) {
         SimpleMailMessage message = new SimpleMailMessage();
         message.setTo(to);
@@ -18,6 +22,7 @@ public class EmailSender {
         message.setText(text);
         try {
             javaMailSender.send(message);
+            log.info("이메일 전송 성공! 수신자 : " + to);
         } catch (MailException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/com/bttf/queosk/service/UserInfoService.java
+++ b/src/main/java/com/bttf/queosk/service/UserInfoService.java
@@ -16,6 +16,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.UUID;
 
+import static com.bttf.queosk.enumerate.EmailComponents.PASSWORD_RESET_SUBJECT;
+import static com.bttf.queosk.enumerate.EmailComponents.PASSWORD_RESET_TEXT;
 import static com.bttf.queosk.enumerate.UserStatus.DELETED;
 import static com.bttf.queosk.enumerate.UserStatus.VERIFIED;
 import static com.bttf.queosk.exception.ErrorCode.*;
@@ -88,15 +90,14 @@ public class UserInfoService {
 
         String encryptedPassword = passwordEncoder.encode(randomPassword);
 
-        emailSender.sendEmail(
-                user.getEmail(),
-                "비밀번호 초기화 완료",
-                "새로운 비밀번호 : " + randomPassword + "를 입력해 로그인 해주세요."
-        );
-
         user.setPassword(encryptedPassword);
 
         userRepository.save(user);
+
+        emailSender.sendEmail(
+                user.getEmail(),
+                PASSWORD_RESET_SUBJECT,
+                String.format(PASSWORD_RESET_TEXT, randomPassword));
     }
 
     @Transactional

--- a/src/main/java/com/bttf/queosk/service/UserLoginService.java
+++ b/src/main/java/com/bttf/queosk/service/UserLoginService.java
@@ -11,6 +11,8 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import static com.bttf.queosk.enumerate.EmailComponents.VERIFICATION_SUBJECT;
+import static com.bttf.queosk.enumerate.EmailComponents.VERIFICATION_TEXT;
 import static com.bttf.queosk.enumerate.UserStatus.DELETED;
 import static com.bttf.queosk.enumerate.UserStatus.NOT_VERIFIED;
 import static com.bttf.queosk.exception.ErrorCode.*;
@@ -46,10 +48,8 @@ public class UserLoginService {
 
         //회원 이메일 주소로 인증이메일 전송
         emailSender.sendEmail(userSignUpRequestForm.getEmail(),
-                "Queosk 이메일 인증",
-                String.format("Queosk에 가입해 주셔서 감사합니다. \n" +
-                        "아래 링크를 클릭 하시어 이메일 인증을 완료해주세요.\n" +
-                        "https://queosk.kr/api/users/%d/verification", user.getId()));
+                VERIFICATION_SUBJECT,
+                String.format(VERIFICATION_TEXT, user.getId()));
     }
 
     @Transactional

--- a/src/test/java/com/bttf/queosk/service/ConcurrencyTest.java
+++ b/src/test/java/com/bttf/queosk/service/ConcurrencyTest.java
@@ -1,0 +1,206 @@
+package com.bttf.queosk.service;
+
+import com.bttf.queosk.dto.QueueCreationRequestForm;
+import com.bttf.queosk.entity.Queue;
+import com.bttf.queosk.entity.Restaurant;
+import com.bttf.queosk.repository.QueueRedisRepository;
+import com.bttf.queosk.repository.QueueRepository;
+import com.bttf.queosk.repository.RestaurantRepository;
+import com.bttf.queosk.repository.UserRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.mockito.Mockito.*;
+
+@DisplayName("동시성 테스트")
+public class ConcurrencyTest {
+
+    private QueueService queueService;
+
+    @Mock
+    private RestaurantRepository restaurantRepository;
+
+    @Mock
+    private FcmService fcmService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private QueueRepository queueRepository;
+
+    @Mock
+    private QueueRedisRepository queueRedisRepository;
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        queueService = new QueueService(
+                userRepository,
+                restaurantRepository,
+                queueRedisRepository,
+                queueRepository,
+                fcmService
+        );
+    }
+
+    @Test
+    @DisplayName("동시에 큐 생성")
+    public void testConcurrentCreateQueue() throws InterruptedException {
+        //given
+        int numThreads = 5; // 동시에 실행할 스레드 수
+        ExecutorService executorService = Executors.newFixedThreadPool(numThreads);
+
+        CountDownLatch countDownLatch = new CountDownLatch(numThreads);
+
+        QueueCreationRequestForm queueCreationRequestForm = QueueCreationRequestForm.builder()
+                .numberOfParty(1L)
+                .build();
+
+        Long userId = 1L;
+        Long restaurantId = 1L;
+
+        // 모의 객체 설정
+        Restaurant mockRestaurant = Restaurant.builder().id(1L).build();
+        Queue mockQueue = Queue.builder().id(1L).userId(1L).restaurantId(1L).build();
+
+        when(restaurantRepository.findById(restaurantId)).thenReturn(Optional.of(mockRestaurant));
+        when(queueRepository.save(any(Queue.class))).thenReturn(mockQueue);
+        when(queueRedisRepository.setIfNotExists(anyString(), anyString())).thenReturn(true);
+
+        // 동시성 테스트용 Runnable 정의
+        Runnable createQueueTask = () -> {
+            try {
+                queueService.createQueue(queueCreationRequestForm, userId, restaurantId);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+            countDownLatch.countDown();
+        };
+        //when(병렬로 스레드 실행)
+        for (int i = 0; i < numThreads; i++) {
+            executorService.execute(createQueueTask);
+        }
+
+        // 모든 스레드가 완료될 때까지 대기
+        if (!countDownLatch.await(10, TimeUnit.SECONDS)) {
+            Assertions.fail("Timeout");
+        }
+
+        //then
+        verify(queueRedisRepository,times(5))
+                .createQueue("1", "1");
+    }
+
+    @Test
+    @DisplayName("동시에 큐 당기기")
+    public void testConcurrentPopTheFirstTeamOfQueue() throws InterruptedException {
+        //given
+        int numThreads = 5; // 동시에 실행할 스레드 수
+        ExecutorService executorService = Executors.newFixedThreadPool(numThreads);
+
+        AtomicReference<String> poppedQueueId = new AtomicReference<>(null);
+
+        CountDownLatch countDownLatch = new CountDownLatch(numThreads);
+
+        Long restaurantId = 1L;
+        when(queueRedisRepository.popTheFirstTeamOfQueue(String.valueOf(1)))
+                .thenReturn("1");
+        when(queueRepository.findById(1L)).thenReturn(Optional.of(new Queue()));
+        when(queueRedisRepository.popTheFirstTeamOfQueue(anyString()))
+                .thenAnswer(invocation -> {
+                    if (poppedQueueId.get() == null) {
+                        poppedQueueId.set("1");
+                        return "1";
+                    }
+                    return null;
+                });
+
+        when(queueRepository.findById(1L))
+                .thenAnswer(invocation -> {
+                    if (poppedQueueId.get() != null) {
+                        return Optional.of(new Queue());
+                    } else {
+                        return Optional.empty();
+                    }
+                });
+
+        // 동시성 테스트용 Runnable 정의
+        Runnable popTheFirstTeamTask = () -> {
+            try {
+                queueService.popTheFirstTeamOfQueue(restaurantId);
+            } catch (Exception e) {
+            e.printStackTrace();
+        }
+        countDownLatch.countDown();
+        };
+
+        //when(병렬로 스레드 실행)
+        for (int i = 0; i < numThreads; i++) {
+            executorService.execute(popTheFirstTeamTask);
+        }
+
+        // 모든 스레드가 완료될 때까지 대기 (10초 제한, 필요에 따라 조절)
+        if (!countDownLatch.await(10, TimeUnit.SECONDS)) {
+            Assertions.fail("Timeout");
+        }
+
+        //then
+        verify(queueRedisRepository,  times(5))
+                .findAll("1");
+    }
+
+    @Test
+    @DisplayName("동시에 큐 삭제")
+    public void testConcurrentDeleteUserQueue() throws InterruptedException {
+        int numThreads = 5; // 동시에 실행할 스레드 수
+        ExecutorService executorService = Executors.newFixedThreadPool(numThreads);
+
+        CountDownLatch countDownLatch = new CountDownLatch(numThreads);
+        Queue mockQueue = Queue.builder().id(1L).userId(1L).restaurantId(1L).build();
+
+        Long userId = 1L;
+        Long restaurantId = 1L;
+
+        when(queueRepository.findFirstByUserIdAndRestaurantIdOrderByCreatedAtDesc(userId, restaurantId))
+                .thenReturn(Optional.of(mockQueue));
+        when(queueRedisRepository.getUserWaitingCount(anyString(), anyString()))
+                .thenReturn(1L);
+        when(queueRedisRepository.setIfNotExists(anyString(), anyString())).thenReturn(true);
+
+        // 동시성 테스트용 Runnable 정의
+        Runnable deleteUserQueueTask = () -> {
+            try {
+                queueService.deleteUserQueue(restaurantId, userId);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+            countDownLatch.countDown();
+        };
+
+        // 병렬로 스레드 실행
+        for (int i = 0; i < numThreads; i++) {
+            executorService.execute(deleteUserQueueTask);
+        }
+
+        // 모든 스레드가 완료될 때까지 대기
+        if (!countDownLatch.await(10, TimeUnit.SECONDS)) {
+            Assertions.fail("Timeout");
+        }
+
+        //then
+        verify(queueRedisRepository, times(numThreads))
+                .deleteQueue("1","1");
+    }
+}

--- a/src/test/java/com/bttf/queosk/service/QueueServiceTest.java
+++ b/src/test/java/com/bttf/queosk/service/QueueServiceTest.java
@@ -89,6 +89,8 @@ class QueueServiceTest {
                         String.valueOf(mockQueue.getId())))
                 .thenReturn(null);
 
+        when(queueRedisRepository.setIfNotExists(anyString(), anyString())).thenReturn(true);
+
         // when
         queueService.createQueue(queueCreationRequestForm, mockUser.getId(), mockRestaurant.getId());
 

--- a/src/test/java/com/bttf/queosk/service/ReviewServiceTest.java
+++ b/src/test/java/com/bttf/queosk/service/ReviewServiceTest.java
@@ -55,6 +55,7 @@ class ReviewServiceTest {
                 .build();
 
         Restaurant restaurant = Restaurant.builder()
+                .ratingAverage(1.0)
                 .id(1L)
                 .build();
         given(userRepository.findById(1L)).willReturn(Optional.of(user));


### PR DESCRIPTION
### 작업 내용
- 웨이팅 등록/삭제/당기기 시 동시성 제어를 통해 데이터 무결성 유지
- 리뷰 등록 시 사용자 별점 업데이트 시 동시성 제어를 통해 데이터 무결성 유지 
- 회원가입 시 비동기처리로 이메일 전송으로 인해 느렸던 api응답속도 개선
### 변경 사항(추가시엔 추가사항)
- 웨이팅 등록시 레디스의 `분산락`을 사용하여 동시성 제어
- 리뷰 등록 시 `명시적락`을 사용하여 동시성 제어
- 이메일 전송 메서드를 `@Async`를 사용하여 비동기 처리

### 특이 사항
- 동시성 테스트 코드 작성완료 
- 기존 테스트코드 수정완료
